### PR TITLE
Fix/카카오액세스토큰수정(사용X)

### DIFF
--- a/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
@@ -8,6 +8,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class KakaoLoginRequest {
 
-    @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
-    private String accessToken;
+    /**
+     * 카카오 로그인 인가 코드 (authorization_code)
+     * 프론트(또는 Swagger)에서 전달받는 값
+     */
+    @NotBlank(message = "카카오 인가 코드는 필수입니다.")
+    private String authorizationCode;
 }

--- a/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
@@ -1,17 +1,12 @@
 package plango.auth.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class KakaoLoginRequest {
-
-    /**
-     * 카카오 로그인 인가 코드 (authorization_code)
-     * 프론트(또는 Swagger)에서 전달받는 값
-     */
-    @NotBlank(message = "카카오 인가 코드는 필수입니다.")
-    private String authorizationCode;
+/**
+ * 카카오 로그인 인가 코드 요청 DTO
+ */
+public record KakaoLoginRequest(
+        @NotBlank(message = "카카오 인가 코드는 필수입니다.")
+        String authorizationCode
+) {
 }

--- a/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
@@ -1,30 +1,25 @@
 package plango.auth.application.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import plango.member.domain.entity.Member;
 
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class KakaoLoginResponse {
-
-    private Long memberId;
-    private String email;
-    private String nickname;
-    private String profileImageUrl;
-    private boolean newMember;
+/**
+ * 카카오 로그인 응답 DTO
+ */
+public record KakaoLoginResponse(
+        Long memberId,
+        String email,
+        String nickname,
+        String profileImageUrl,
+        boolean newMember
+) {
 
     public static KakaoLoginResponse of(Member member, boolean newMember) {
-        return KakaoLoginResponse.builder()
-                .memberId(member.getId())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
-                .newMember(newMember)
-                .build();
+        return new KakaoLoginResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getProfileImageUrl(),
+                newMember
+        );
     }
 }

--- a/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
@@ -3,9 +3,12 @@ package plango.auth.application.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plango.member.domain.entity.Member;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class KakaoLoginResponse {
 
@@ -13,4 +16,15 @@ public class KakaoLoginResponse {
     private String email;
     private String nickname;
     private String profileImageUrl;
+    private boolean newMember;
+
+    public static KakaoLoginResponse of(Member member, boolean newMember) {
+        return KakaoLoginResponse.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .newMember(newMember)
+                .build();
+    }
 }

--- a/src/main/java/plango/auth/application/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,27 @@
+package plango.auth.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;           // ex) "bearer"
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Long refreshTokenExpiresIn;
+
+    private String scope;
+}

--- a/src/main/java/plango/auth/application/dto/response/KakaoUserInfo.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoUserInfo.java
@@ -1,0 +1,57 @@
+package plango.auth.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfo {
+
+    /**
+     * 카카오 유저 고유 ID
+     */
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+
+        private String email;
+        private Profile profile;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Profile {
+
+        private String nickname;
+
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+    }
+
+    // 편의 메서드들
+    public String getEmail() {
+        return kakaoAccount != null ? kakaoAccount.getEmail() : null;
+    }
+
+    public String getNickname() {
+        return (kakaoAccount != null && kakaoAccount.getProfile() != null)
+                ? kakaoAccount.getProfile().getNickname()
+                : null;
+    }
+
+    public String getProfileImageUrl() {
+        return (kakaoAccount != null && kakaoAccount.getProfile() != null)
+                ? kakaoAccount.getProfile().getProfileImageUrl()
+                : null;
+    }
+}

--- a/src/main/java/plango/auth/application/mapper/KakaoAuthMapper.java
+++ b/src/main/java/plango/auth/application/mapper/KakaoAuthMapper.java
@@ -1,0 +1,32 @@
+package plango.auth.application.mapper;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import plango.auth.application.dto.response.KakaoLoginResponse;
+import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.member.domain.entity.Member;
+
+/**
+ * Kakao 인증 관련 Entity/DTO 매핑 담당
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KakaoAuthMapper {
+
+    /**
+     * Kakao 사용자 정보 → Member 엔티티 매핑
+     */
+    public static Member toMember(KakaoUserInfo kakaoUserInfo) {
+        return Member.createKakaoMember(
+                kakaoUserInfo.getEmail(),
+                kakaoUserInfo.getNickname(),
+                kakaoUserInfo.getProfileImageUrl()
+        );
+    }
+
+    /**
+     * Member 엔티티 → KakaoLoginResponse DTO 매핑
+     */
+    public static KakaoLoginResponse toKakaoLoginResponse(Member member, boolean newMember) {
+        return KakaoLoginResponse.of(member, newMember);
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
@@ -1,18 +1,60 @@
 package plango.auth.application.usecase;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import plango.auth.application.dto.request.KakaoLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
+import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.auth.domain.entity.SocialAccount;
+import plango.auth.domain.repository.SocialAccountRepository;
 import plango.auth.domain.service.KakaoAuthService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.repository.MemberRepository;
 
-@Component
+@Service
 @RequiredArgsConstructor
 public class KakaoLoginUseCase {
 
     private final KakaoAuthService kakaoAuthService;
+    private final MemberRepository memberRepository;
+    private final SocialAccountRepository socialAccountRepository;
 
+    @Transactional
     public KakaoLoginResponse execute(KakaoLoginRequest request) {
-        return kakaoAuthService.login(request.getAccessToken());
+
+        // 1) 인가 코드 → 카카오 유저 정보 조회
+        KakaoUserInfo kakaoUserInfo =
+                kakaoAuthService.getUserInfoByAuthorizationCode(request.getAuthorizationCode());
+
+        Long kakaoId = kakaoUserInfo.getId();
+        String email = kakaoUserInfo.getEmail();
+        String nickname = kakaoUserInfo.getNickname();
+        String profileImageUrl = kakaoUserInfo.getProfileImageUrl();
+
+        // 2) 소셜 계정 존재 여부 확인
+        SocialAccount socialAccount =
+                socialAccountRepository.findByProviderAndProviderUserId("KAKAO", kakaoId.toString())
+                        .orElse(null);
+
+        boolean isNewMember = false;
+        Member member;
+
+        if (socialAccount == null) {
+            // 처음 로그인하는 카카오 계정 → 회원 + 소셜 계정 생성
+            member = Member.createKakaoMember(email, nickname, profileImageUrl);
+            memberRepository.save(member);
+
+            socialAccount = SocialAccount.createKakaoAccount(kakaoId.toString(), member);
+            socialAccountRepository.save(socialAccount);
+
+            isNewMember = true;
+        } else {
+            // 기존 회원
+            member = socialAccount.getMember();
+        }
+
+        // 3) 응답 DTO 생성 (필요하면 JWT 로직 추가)
+        return KakaoLoginResponse.of(member, isNewMember);
     }
 }

--- a/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import plango.auth.application.dto.request.KakaoLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.auth.application.mapper.KakaoAuthMapper;
 import plango.auth.domain.entity.SocialAccount;
 import plango.auth.domain.repository.SocialAccountRepository;
 import plango.auth.domain.service.KakaoAuthService;
@@ -16,45 +17,53 @@ import plango.member.domain.repository.MemberRepository;
 @RequiredArgsConstructor
 public class KakaoLoginUseCase {
 
+    private static final String KAKAO_PROVIDER = "KAKAO";
+
     private final KakaoAuthService kakaoAuthService;
     private final MemberRepository memberRepository;
     private final SocialAccountRepository socialAccountRepository;
 
     @Transactional
     public KakaoLoginResponse execute(KakaoLoginRequest request) {
-
-        // 1) 인가 코드 → 카카오 유저 정보 조회
+        // 1) 인가 코드로 카카오 사용자 정보 조회
         KakaoUserInfo kakaoUserInfo =
-                kakaoAuthService.getUserInfoByAuthorizationCode(request.getAuthorizationCode());
+                kakaoAuthService.getUserInfoByAuthorizationCode(request.authorizationCode());
 
         Long kakaoId = kakaoUserInfo.getId();
-        String email = kakaoUserInfo.getEmail();
-        String nickname = kakaoUserInfo.getNickname();
-        String profileImageUrl = kakaoUserInfo.getProfileImageUrl();
 
-        // 2) 소셜 계정 존재 여부 확인
-        SocialAccount socialAccount =
-                socialAccountRepository.findByProviderAndProviderUserId("KAKAO", kakaoId.toString())
-                        .orElse(null);
+        // 2) 기존 소셜 계정 존재 여부 확인
+        SocialAccount socialAccount = socialAccountRepository
+                .findByProviderAndProviderUserId(KAKAO_PROVIDER, kakaoId.toString())
+                .orElse(null);
 
-        boolean isNewMember = false;
         Member member;
+        boolean isNewMember;
 
         if (socialAccount == null) {
-            // 처음 로그인하는 카카오 계정 → 회원 + 소셜 계정 생성
-            member = Member.createKakaoMember(email, nickname, profileImageUrl);
-            memberRepository.save(member);
+            // 이메일 기준으로 기존 회원 여부 확인
+            String email = kakaoUserInfo.getEmail();
+            member = (email != null && !email.isBlank())
+                    ? memberRepository.findByEmail(email).orElse(null)
+                    : null;
 
+            // 완전 신규 회원이면 생성
+            if (member == null) {
+                member = KakaoAuthMapper.toMember(kakaoUserInfo);
+                memberRepository.save(member);
+            }
+
+            // 소셜 계정 연결
             socialAccount = SocialAccount.createKakaoAccount(kakaoId.toString(), member);
             socialAccountRepository.save(socialAccount);
 
             isNewMember = true;
         } else {
-            // 기존 회원
+            // 이미 소셜 계정이 연결된 기존 회원
             member = socialAccount.getMember();
+            isNewMember = false;
         }
 
-        // 3) 응답 DTO 생성 (필요하면 JWT 로직 추가)
-        return KakaoLoginResponse.of(member, isNewMember);
+        // 3) 응답 DTO 매핑 (추후 JWT 토큰 추가 가능)
+        return KakaoAuthMapper.toKakaoLoginResponse(member, isNewMember);
     }
 }

--- a/src/main/java/plango/auth/domain/entity/SocialAccount.java
+++ b/src/main/java/plango/auth/domain/entity/SocialAccount.java
@@ -9,6 +9,7 @@ import plango.member.domain.entity.Member;
 
 @Getter
 @Entity
+@Table(name = "social_account")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SocialAccount extends BaseTimeEntity {
 
@@ -23,9 +24,10 @@ public class SocialAccount extends BaseTimeEntity {
     private String provider;
 
     /**
-     * 제공자 쪽의 고유 사용자 ID (예: 카카오 id)
+     * 제공자 쪽의 고유 사용자 ID
+     *  - DB 컬럼명: provider_uid
      */
-    @Column(nullable = false, length = 100)
+    @Column(name = "provider_uid", nullable = false, length = 100)
     private String providerUserId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/plango/auth/domain/entity/SocialAccount.java
+++ b/src/main/java/plango/auth/domain/entity/SocialAccount.java
@@ -1,39 +1,48 @@
 package plango.auth.domain.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
-import plango.member.domain.entity.Member;
 import plango.global.common.entity.BaseTimeEntity;
+import plango.member.domain.entity.Member;
 
 @Getter
-@SuperBuilder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "social_account")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SocialAccount extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /**
+     * 소셜 로그인 제공자 (예: KAKAO, GOOGLE 등)
+     */
     @Column(nullable = false, length = 20)
     private String provider;
 
-    @Column(name = "provider_uid", nullable = false, length = 100, unique = true)
-    private String providerUid;
+    /**
+     * 제공자 쪽의 고유 사용자 ID (예: 카카오 id)
+     */
+    @Column(nullable = false, length = 100)
+    private String providerUserId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    // ===== 연관관계 편의 메서드 =====
+    private void setMember(Member member) {
+        this.member = member;
+    }
+
+    // ===== 정적 팩토리 메서드 =====
+    public static SocialAccount createKakaoAccount(String providerUserId, Member member) {
+        SocialAccount socialAccount = new SocialAccount();
+        socialAccount.provider = "KAKAO";
+        socialAccount.providerUserId = providerUserId;
+        socialAccount.setMember(member);
+        return socialAccount;
+    }
 }

--- a/src/main/java/plango/auth/domain/repository/SocialAccountRepository.java
+++ b/src/main/java/plango/auth/domain/repository/SocialAccountRepository.java
@@ -1,10 +1,11 @@
 package plango.auth.domain.repository;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import plango.auth.domain.entity.SocialAccount;
 
+import java.util.Optional;
+
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
 
-    Optional<SocialAccount> findByProviderAndProviderUid(String provider, String providerUid);
+    Optional<SocialAccount> findByProviderAndProviderUserId(String provider, String providerUserId);
 }

--- a/src/main/java/plango/auth/domain/service/KakaoAuthService.java
+++ b/src/main/java/plango/auth/domain/service/KakaoAuthService.java
@@ -1,152 +1,92 @@
 package plango.auth.domain.service;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClientException;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import plango.auth.application.dto.response.KakaoLoginResponse;
-import plango.member.domain.entity.Member;
-import plango.auth.domain.entity.SocialAccount;
-import plango.member.domain.repository.MemberRepository;
-import plango.auth.domain.repository.SocialAccountRepository;
-import plango.global.common.exception.BusinessException;
-import plango.global.common.exception.ErrorCode;
+import plango.auth.application.dto.response.KakaoTokenResponse;
+import plango.auth.application.dto.response.KakaoUserInfo;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoAuthService {
 
-    private static final String KAKAO_PROVIDER = "KAKAO";
-    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
-
     private final RestTemplate restTemplate;
-    private final MemberRepository memberRepository;
-    private final SocialAccountRepository socialAccountRepository;
 
-    public KakaoLoginResponse login(String accessToken) {
-        KakaoUserResponse kakaoUserResponse = requestKakaoUser(accessToken);
+    @Value("${kakao.client-id}")
+    private String clientId;
 
-        Long kakaoId = kakaoUserResponse.getId();
-        KakaoUserResponse.KakaoAccount account = kakaoUserResponse.getKakaoAccount();
+    @Value("${kakao.client-secret:}")
+    private String clientSecret;
 
-        String email = account != null ? account.getEmail() : null;
-        String nickname = account != null && account.getProfile() != null
-                ? account.getProfile().getNickname()
-                : "카카오사용자";
-        String profileImageUrl = account != null && account.getProfile() != null
-                ? account.getProfile().getProfileImageUrl()
-                : null;
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
 
-        String providerUid = String.valueOf(kakaoId);
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
 
-        SocialAccount socialAccount = socialAccountRepository
-                .findByProviderAndProviderUid(KAKAO_PROVIDER, providerUid)
-                .orElseGet(() -> createMemberAndSocialAccount(providerUid, email, nickname, profileImageUrl));
+    /**
+     * 인가 코드로 카카오 access token 발급 후, 해당 토큰으로 유저 정보 조회
+     */
+    public KakaoUserInfo getUserInfoByAuthorizationCode(String authorizationCode) {
+        KakaoTokenResponse tokenResponse = fetchAccessToken(authorizationCode);
 
-        Member member = socialAccount.getMember();
+        String accessToken = tokenResponse.getAccessToken();
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalStateException("카카오 access token 발급에 실패했습니다.");
+        }
 
-        return KakaoLoginResponse.builder()
-                .memberId(member.getId())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
-                .build();
+        return fetchUserInfo(accessToken);
     }
 
-    private KakaoUserResponse requestKakaoUser(String accessToken) {
+    private KakaoTokenResponse fetchAccessToken(String authorizationCode) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", authorizationCode);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            params.add("client_secret", clientSecret);
+        }
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<KakaoTokenResponse> response =
+                restTemplate.postForEntity(TOKEN_URL, request, KakaoTokenResponse.class);
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            log.warn("카카오 토큰 발급 실패. status={}, body={}",
+                    response.getStatusCode(), response.getBody());
+            throw new IllegalStateException("카카오 토큰 발급 요청에 실패했습니다.");
+        }
+
+        return response.getBody();
+    }
+
+    private KakaoUserInfo fetchUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
 
-        try {
-            ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
-                    KAKAO_USER_INFO_URL,
-                    HttpMethod.GET,
-                    entity,
-                    KakaoUserResponse.class
-            );
+        ResponseEntity<KakaoUserInfo> response =
+                restTemplate.postForEntity(USER_INFO_URL, request, KakaoUserInfo.class);
 
-            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-                throw new BusinessException(
-                        ErrorCode.KAKAO_INVALID_TOKEN.getStatusCode(),
-                        ErrorCode.KAKAO_INVALID_TOKEN.getMessage()
-                );
-            }
-
-            return response.getBody();
-        } catch (HttpClientErrorException e) {
-            throw new BusinessException(
-                    ErrorCode.KAKAO_INVALID_TOKEN.getStatusCode(),
-                    ErrorCode.KAKAO_INVALID_TOKEN.getMessage()
-            );
-        } catch (RestClientException e) {
-            throw new BusinessException(
-                    ErrorCode.KAKAO_SERVER_ERROR.getStatusCode(),
-                    ErrorCode.KAKAO_SERVER_ERROR.getMessage()
-            );
-        }
-    }
-
-    private SocialAccount createMemberAndSocialAccount(
-            String providerUid,
-            String email,
-            String nickname,
-            String profileImageUrl
-    ) {
-        Member member = Member.builder()
-                .email(email)
-                .password(null)
-                .nickname(nickname)
-                .profileImageUrl(profileImageUrl)
-                .build();
-
-        Member savedMember = memberRepository.save(member);
-
-        SocialAccount socialAccount = SocialAccount.builder()
-                .provider(KAKAO_PROVIDER)
-                .providerUid(providerUid)
-                .member(savedMember)
-                .build();
-
-        return socialAccountRepository.save(socialAccount);
-    }
-
-    @Getter
-    @Setter
-    private static class KakaoUserResponse {
-
-        private Long id;
-
-        @JsonProperty("kakao_account")
-        private KakaoAccount kakaoAccount;
-
-        @Getter
-        @Setter
-        private static class KakaoAccount {
-
-            private String email;
-            private Profile profile;
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            log.warn("카카오 사용자 정보 조회 실패. status={}, body={}",
+                    response.getStatusCode(), response.getBody());
+            throw new IllegalStateException("카카오 사용자 정보 조회에 실패했습니다.");
         }
 
-        @Getter
-        @Setter
-        private static class Profile {
-
-            private String nickname;
-
-            @JsonProperty("profile_image_url")
-            private String profileImageUrl;
-        }
+        return response.getBody();
     }
 }

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -1,12 +1,9 @@
 package plango.auth.presentation;
 
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import plango.auth.application.dto.request.KakaoLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.usecase.KakaoLoginUseCase;
@@ -14,21 +11,19 @@ import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
     private final KakaoLoginUseCase kakaoLoginUseCase;
 
-    @Operation(summary = "카카오 로그인", description = "카카오 액세스 토큰으로 로그인합니다.")
-    @PostMapping("/kakao")
-    public CommonResponse<KakaoLoginResponse> kakaoLogin(
-            @Valid @RequestBody KakaoLoginRequest request
+    @PostMapping("/kakao/login")
+    public ResponseEntity<CommonResponse<KakaoLoginResponse>> kakaoLogin(
+            @RequestBody @Valid KakaoLoginRequest request
     ) {
         KakaoLoginResponse response = kakaoLoginUseCase.execute(request);
-        return CommonResponse.createSuccess(
-                ResponseMessage.KAKAO_LOGIN_SUCCESS.getMessage(),
-                response
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.KAKAO_LOGIN_SUCCESS, response)
         );
     }
 }

--- a/src/main/java/plango/global/common/response/CommonResponse.java
+++ b/src/main/java/plango/global/common/response/CommonResponse.java
@@ -1,9 +1,19 @@
 package plango.global.common.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+/**
+ * 모든 API 응답을 감싸는 공통 응답 객체
+ *  - code    : 비즈니스/HTTP 코드
+ *  - message : 응답 메시지
+ *  - data    : 실제 응답 데이터
+ */
 @Getter
+@Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class CommonResponse<T> {
 
@@ -11,19 +21,56 @@ public class CommonResponse<T> {
     private String message;
     private T data;
 
-    public static <T> CommonResponse<T> createSuccess(String message) {
-        return new CommonResponse<>(200, message, null);
+    // =======================
+    // 성공 응답
+    // =======================
+
+    /** ResponseMessage 기반 성공 응답 */
+    public static <T> CommonResponse<T> success(ResponseMessage message, T data) {
+        return CommonResponse.<T>builder()
+                .code(message.getCode())
+                .message(message.getMessage())
+                .data(data)
+                .build();
     }
 
-    public static <T> CommonResponse<T> createSuccess(String message, T data) {
-        return new CommonResponse<>(200, message, data);
+    /** 임의 메시지 기반 성공 응답 */
+    public static <T> CommonResponse<T> success(String message, T data) {
+        return CommonResponse.<T>builder()
+                .code(0)
+                .message(message)
+                .data(data)
+                .build();
     }
 
-    public static <T> CommonResponse<T> createFailure(int statusCode, String message) {
-        return new CommonResponse<>(statusCode, message, null);
+    // =======================
+    // 실패 응답 (기존 + createFailure 추가)
+    // =======================
+
+    /** 간단 실패 응답 (code + message, data 는 null) */
+    public static <T> CommonResponse<T> fail(ResponseMessage message) {
+        return CommonResponse.<T>builder()
+                .code(message.getCode())
+                .message(message.getMessage())
+                .data(null)
+                .build();
     }
 
-    public static <T> CommonResponse<T> createFailure(int statusCode, String message, T data) {
-        return new CommonResponse<>(statusCode, message, data);
+    /** GlobalExceptionHandler 에서 사용하는 실패 응답 (data 없음) */
+    public static <T> CommonResponse<T> createFailure(int code, String message) {
+        return CommonResponse.<T>builder()
+                .code(code)
+                .message(message)
+                .data(null)
+                .build();
+    }
+
+    /** GlobalExceptionHandler 에서 사용하는 실패 응답 (data 포함) */
+    public static <T> CommonResponse<T> createFailure(int code, String message, T data) {
+        return CommonResponse.<T>builder()
+                .code(code)
+                .message(message)
+                .data(data)
+                .build();
     }
 }

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -3,11 +3,19 @@ package plango.global.common.response;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 비즈니스 응답 코드 & 메시지 정의
+ */
 @Getter
 @RequiredArgsConstructor
 public enum ResponseMessage {
 
-    KAKAO_LOGIN_SUCCESS("카카오 로그인에 성공했습니다.");
+    // ===== 공통 =====
+    SUCCESS(0, "성공"),
 
+    // ===== 인증 / 카카오 로그인 =====
+    KAKAO_LOGIN_SUCCESS(1000, "카카오 로그인에 성공했습니다.");
+
+    private final int code;
     private final String message;
 }

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -1,37 +1,35 @@
 package plango.member.domain.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import plango.global.common.entity.BaseTimeEntity;
 
 @Getter
-@SuperBuilder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, length = 100)
+    @Column(nullable = false, unique = true, length = 100)
     private String email;
-
-    @Column(length = 200)
-    private String password;
 
     @Column(nullable = false, length = 50)
     private String nickname;
 
-    @Column(name = "profile_image_url", length = 255)
+    @Column(length = 255)
     private String profileImageUrl;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static Member createKakaoMember(String email, String nickname, String profileImageUrl) {
+        Member member = new Member();
+        member.email = email;
+        member.nickname = nickname;
+        member.profileImageUrl = profileImageUrl;
+        return member;
+    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -55,5 +55,6 @@ preview:
 kakao:
   client-id: "6ecbd75cc6c1f3a8819f66e5698ee294"
   client-secret: ""
-  redirect-uri: "http://ceprj2.gachon.ac.kr:8080/login/oauth2/code/kakao"
+  redirect-uri: "http://ceprj2.gachon.ac.kr:65028/login/oauth2/code/kakao"
+
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -55,5 +55,5 @@ preview:
 kakao:
   client-id: "6ecbd75cc6c1f3a8819f66e5698ee294"
   client-secret: ""
-  redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+  redirect-uri: "http://ceprj2.gachon.ac.kr:8080/login/oauth2/code/kakao"
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -51,3 +51,9 @@ security:
 preview:
   api:
     url: ${PREVIEW_API_URL:http://localhost:3000}
+
+kakao:
+  client-id: "6ecbd75cc6c1f3a8819f66e5698ee294"
+  client-secret: ""
+  redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #18  

## 🔎 작업 내용

- 카카오 OAuth2 인증 플로우 구현
- 레코드(record) 기반 DTO 리팩토링
- Mapper 분리 (컨벤션 준수)
- UseCase 구조 정리
- 리다이렉트 URI 및 팀 서버 포트 반영
- 학과 서버 배포 및 통합 테스트 완료

<br>


## 📌 참고 사항

- 집중 리뷰 <!--(선택 사항)-->
    - DTO를 record로 변경한 부분이 팀 컨벤션에 적합한지 확인 부탁드립니다.
    - Mapper 분리 구조(KakaoAuthMapper)가 서비스 전체 구조와 잘 맞는지 검토 부탁드립니다.
    - UseCase 로직 책임 분배가 적절한지 피드백 부탁드립니다.
- 기타 안내 사항 <!--(선택 사항)-->
    - 현재는 인가 코드만 받아서 로그인하는 구조이며, JWT 발급/세션 처리 등은 이후 PR에서 추가 예정입니다.
    - 카카오 access token은 서버에서 자동 발급하도록 구현되어 Swagger에서는 인가 코드만 입력하면 됩니다.
<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
<img width="1413" height="831" alt="카카오 로그인 인가 코드 구현" src="https://github.com/user-attachments/assets/33fca569-624d-4baf-b259-6301feccc390" />
" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수