### PR TITLE
Fix/11/카카오엑세스토큰수정

### DIFF
--- a/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
@@ -3,7 +3,8 @@ package plango.auth.application.dto.request;
 import jakarta.validation.constraints.NotBlank;
 
 /**
- * 카카오 로그인 인가 코드 요청 DTO
+ * 카카오 로그인 요청 DTO
+ *  - authorizationCode : 카카오 인가 코드 (authorization_code)
  */
 public record KakaoLoginRequest(
         @NotBlank(message = "카카오 인가 코드는 필수입니다.")

--- a/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
@@ -8,6 +8,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class KakaoLoginRequest {
 
-    @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
-    private String accessToken;
+    /**
+     * 카카오 로그인 인가 코드 (authorization_code)
+     * 프론트(또는 Swagger)에서 전달받는 값
+     */
+    @NotBlank(message = "카카오 인가 코드는 필수입니다.")
+    private String authorizationCode;
 }

--- a/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/KakaoLoginRequest.java
@@ -1,17 +1,12 @@
 package plango.auth.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class KakaoLoginRequest {
-
-    /**
-     * 카카오 로그인 인가 코드 (authorization_code)
-     * 프론트(또는 Swagger)에서 전달받는 값
-     */
-    @NotBlank(message = "카카오 인가 코드는 필수입니다.")
-    private String authorizationCode;
+/**
+ * 카카오 로그인 인가 코드 요청 DTO
+ */
+public record KakaoLoginRequest(
+        @NotBlank(message = "카카오 인가 코드는 필수입니다.")
+        String authorizationCode
+) {
 }

--- a/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
@@ -1,30 +1,25 @@
 package plango.auth.application.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import plango.member.domain.entity.Member;
 
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class KakaoLoginResponse {
-
-    private Long memberId;
-    private String email;
-    private String nickname;
-    private String profileImageUrl;
-    private boolean newMember;
+/**
+ * 카카오 로그인 응답 DTO
+ */
+public record KakaoLoginResponse(
+        Long memberId,
+        String email,
+        String nickname,
+        String profileImageUrl,
+        boolean newMember
+) {
 
     public static KakaoLoginResponse of(Member member, boolean newMember) {
-        return KakaoLoginResponse.builder()
-                .memberId(member.getId())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
-                .newMember(newMember)
-                .build();
+        return new KakaoLoginResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getProfileImageUrl(),
+                newMember
+        );
     }
 }

--- a/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
@@ -3,9 +3,12 @@ package plango.auth.application.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plango.member.domain.entity.Member;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class KakaoLoginResponse {
 
@@ -13,4 +16,15 @@ public class KakaoLoginResponse {
     private String email;
     private String nickname;
     private String profileImageUrl;
+    private boolean newMember;
+
+    public static KakaoLoginResponse of(Member member, boolean newMember) {
+        return KakaoLoginResponse.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .newMember(newMember)
+                .build();
+    }
 }

--- a/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoLoginResponse.java
@@ -1,10 +1,8 @@
 package plango.auth.application.dto.response;
 
-import plango.member.domain.entity.Member;
+import lombok.Builder;
 
-/**
- * 카카오 로그인 응답 DTO
- */
+@Builder
 public record KakaoLoginResponse(
         Long memberId,
         String email,
@@ -12,14 +10,4 @@ public record KakaoLoginResponse(
         String profileImageUrl,
         boolean newMember
 ) {
-
-    public static KakaoLoginResponse of(Member member, boolean newMember) {
-        return new KakaoLoginResponse(
-                member.getId(),
-                member.getEmail(),
-                member.getNickname(),
-                member.getProfileImageUrl(),
-                newMember
-        );
-    }
 }

--- a/src/main/java/plango/auth/application/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,27 @@
+package plango.auth.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+
+    @JsonProperty("token_type")
+    private String tokenType;           // ex) "bearer"
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Long refreshTokenExpiresIn;
+
+    private String scope;
+}

--- a/src/main/java/plango/auth/application/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoTokenResponse.java
@@ -1,27 +1,24 @@
 package plango.auth.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class KakaoTokenResponse {
 
-    @JsonProperty("token_type")
-    private String tokenType;           // ex) "bearer"
+public record KakaoTokenResponse(
+        @JsonProperty("token_type")
+        String tokenType,
 
-    @JsonProperty("access_token")
-    private String accessToken;
+        @JsonProperty("access_token")
+        String accessToken,
 
-    @JsonProperty("expires_in")
-    private Long expiresIn;
+        @JsonProperty("expires_in")
+        Long expiresIn,
 
-    @JsonProperty("refresh_token")
-    private String refreshToken;
+        @JsonProperty("refresh_token")
+        String refreshToken,
 
-    @JsonProperty("refresh_token_expires_in")
-    private Long refreshTokenExpiresIn;
+        @JsonProperty("refresh_token_expires_in")
+        Long refreshTokenExpiresIn,
 
-    private String scope;
+        String scope
+) {
 }

--- a/src/main/java/plango/auth/application/dto/response/KakaoUserInfo.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoUserInfo.java
@@ -1,0 +1,57 @@
+package plango.auth.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfo {
+
+    /**
+     * 카카오 유저 고유 ID
+     */
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+
+        private String email;
+        private Profile profile;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Profile {
+
+        private String nickname;
+
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+    }
+
+    // 편의 메서드들
+    public String getEmail() {
+        return kakaoAccount != null ? kakaoAccount.getEmail() : null;
+    }
+
+    public String getNickname() {
+        return (kakaoAccount != null && kakaoAccount.getProfile() != null)
+                ? kakaoAccount.getProfile().getNickname()
+                : null;
+    }
+
+    public String getProfileImageUrl() {
+        return (kakaoAccount != null && kakaoAccount.getProfile() != null)
+                ? kakaoAccount.getProfile().getProfileImageUrl()
+                : null;
+    }
+}

--- a/src/main/java/plango/auth/application/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/KakaoUserInfoResponse.java
@@ -5,18 +5,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class KakaoUserInfo {
+public record KakaoUserInfoResponse(
 
-    /**
-     * 카카오 유저 고유 ID
-     */
-    private Long id;
+        Long id,
 
-    @JsonProperty("kakao_account")
-    private KakaoAccount kakaoAccount;
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
+
+) {
 
     @Getter
     @NoArgsConstructor
@@ -24,6 +21,8 @@ public class KakaoUserInfo {
     public static class KakaoAccount {
 
         private String email;
+
+        @JsonProperty("profile")
         private Profile profile;
     }
 
@@ -38,7 +37,10 @@ public class KakaoUserInfo {
         private String profileImageUrl;
     }
 
-    // 편의 메서드들
+    public Long getId() {
+        return id;
+    }
+
     public String getEmail() {
         return kakaoAccount != null ? kakaoAccount.getEmail() : null;
     }

--- a/src/main/java/plango/auth/application/mapper/KakaoAuthMapper.java
+++ b/src/main/java/plango/auth/application/mapper/KakaoAuthMapper.java
@@ -3,19 +3,13 @@ package plango.auth.application.mapper;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import plango.auth.application.dto.response.KakaoLoginResponse;
-import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.auth.application.dto.response.KakaoUserInfoResponse;
 import plango.member.domain.entity.Member;
 
-/**
- * Kakao 인증 관련 Entity/DTO 매핑 담당
- */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class KakaoAuthMapper {
 
-    /**
-     * Kakao 사용자 정보 → Member 엔티티 매핑
-     */
-    public static Member toMember(KakaoUserInfo kakaoUserInfo) {
+    public static Member toMember(KakaoUserInfoResponse kakaoUserInfo) {
         return Member.createKakaoMember(
                 kakaoUserInfo.getEmail(),
                 kakaoUserInfo.getNickname(),
@@ -23,10 +17,13 @@ public class KakaoAuthMapper {
         );
     }
 
-    /**
-     * Member 엔티티 → KakaoLoginResponse DTO 매핑
-     */
     public static KakaoLoginResponse toKakaoLoginResponse(Member member, boolean newMember) {
-        return KakaoLoginResponse.of(member, newMember);
+        return KakaoLoginResponse.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .newMember(newMember)
+                .build();
     }
 }

--- a/src/main/java/plango/auth/application/mapper/KakaoAuthMapper.java
+++ b/src/main/java/plango/auth/application/mapper/KakaoAuthMapper.java
@@ -1,0 +1,32 @@
+package plango.auth.application.mapper;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import plango.auth.application.dto.response.KakaoLoginResponse;
+import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.member.domain.entity.Member;
+
+/**
+ * Kakao 인증 관련 Entity/DTO 매핑 담당
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KakaoAuthMapper {
+
+    /**
+     * Kakao 사용자 정보 → Member 엔티티 매핑
+     */
+    public static Member toMember(KakaoUserInfo kakaoUserInfo) {
+        return Member.createKakaoMember(
+                kakaoUserInfo.getEmail(),
+                kakaoUserInfo.getNickname(),
+                kakaoUserInfo.getProfileImageUrl()
+        );
+    }
+
+    /**
+     * Member 엔티티 → KakaoLoginResponse DTO 매핑
+     */
+    public static KakaoLoginResponse toKakaoLoginResponse(Member member, boolean newMember) {
+        return KakaoLoginResponse.of(member, newMember);
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
@@ -5,13 +5,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plango.auth.application.dto.request.KakaoLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
-import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.auth.application.dto.response.KakaoUserInfoResponse;
 import plango.auth.application.mapper.KakaoAuthMapper;
 import plango.auth.domain.entity.SocialAccount;
-import plango.auth.domain.repository.SocialAccountRepository;
 import plango.auth.domain.service.KakaoAuthService;
+import plango.auth.domain.service.SocialAccountService;
 import plango.member.domain.entity.Member;
-import plango.member.domain.repository.MemberRepository;
+import plango.member.domain.service.MemberService;
 
 @Service
 @RequiredArgsConstructor
@@ -20,50 +20,43 @@ public class KakaoLoginUseCase {
     private static final String KAKAO_PROVIDER = "KAKAO";
 
     private final KakaoAuthService kakaoAuthService;
-    private final MemberRepository memberRepository;
-    private final SocialAccountRepository socialAccountRepository;
+    private final MemberService memberService;
+    private final SocialAccountService socialAccountService;
 
     @Transactional
     public KakaoLoginResponse execute(KakaoLoginRequest request) {
         // 1) 인가 코드로 카카오 사용자 정보 조회
-        KakaoUserInfo kakaoUserInfo =
+        KakaoUserInfoResponse kakaoUserInfo =
                 kakaoAuthService.getUserInfoByAuthorizationCode(request.authorizationCode());
 
         Long kakaoId = kakaoUserInfo.getId();
+        String email = kakaoUserInfo.getEmail();
 
-        // 2) 기존 소셜 계정 존재 여부 확인
-        SocialAccount socialAccount = socialAccountRepository
+        // 2) 기존 소셜 계정 조회 (서비스 사용)
+        SocialAccount socialAccount = socialAccountService
                 .findByProviderAndProviderUserId(KAKAO_PROVIDER, kakaoId.toString())
                 .orElse(null);
 
         Member member;
-        boolean isNewMember;
+        boolean isNewMember = false;
 
         if (socialAccount == null) {
-            // 이메일 기준으로 기존 회원 여부 확인
-            String email = kakaoUserInfo.getEmail();
-            member = (email != null && !email.isBlank())
-                    ? memberRepository.findByEmail(email).orElse(null)
-                    : null;
+            // 2-1) 기존 회원 조회 (서비스 사용)
+            member = memberService.findByEmail(email)
+                    .orElseGet(() -> memberService.save(KakaoAuthMapper.toMember(kakaoUserInfo)));
 
-            // 완전 신규 회원이면 생성
-            if (member == null) {
-                member = KakaoAuthMapper.toMember(kakaoUserInfo);
-                memberRepository.save(member);
-            }
-
-            // 소셜 계정 연결
-            socialAccount = SocialAccount.createKakaoAccount(kakaoId.toString(), member);
-            socialAccountRepository.save(socialAccount);
-
+            // 2-2) 소셜 계정 생성 및 저장 (서비스 사용)
+            socialAccount = socialAccountService.createAndSaveKakaoAccount(
+                    kakaoId.toString(),
+                    member
+            );
             isNewMember = true;
         } else {
-            // 이미 소셜 계정이 연결된 기존 회원
+            // 기존 회원
             member = socialAccount.getMember();
-            isNewMember = false;
         }
 
-        // 3) 응답 DTO 매핑 (추후 JWT 토큰 추가 가능)
+        // 3) 응답 DTO 매핑
         return KakaoAuthMapper.toKakaoLoginResponse(member, isNewMember);
     }
 }

--- a/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
@@ -1,18 +1,60 @@
 package plango.auth.application.usecase;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import plango.auth.application.dto.request.KakaoLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
+import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.auth.domain.entity.SocialAccount;
+import plango.auth.domain.repository.SocialAccountRepository;
 import plango.auth.domain.service.KakaoAuthService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.repository.MemberRepository;
 
-@Component
+@Service
 @RequiredArgsConstructor
 public class KakaoLoginUseCase {
 
     private final KakaoAuthService kakaoAuthService;
+    private final MemberRepository memberRepository;
+    private final SocialAccountRepository socialAccountRepository;
 
+    @Transactional
     public KakaoLoginResponse execute(KakaoLoginRequest request) {
-        return kakaoAuthService.login(request.getAccessToken());
+
+        // 1) 인가 코드 → 카카오 유저 정보 조회
+        KakaoUserInfo kakaoUserInfo =
+                kakaoAuthService.getUserInfoByAuthorizationCode(request.getAuthorizationCode());
+
+        Long kakaoId = kakaoUserInfo.getId();
+        String email = kakaoUserInfo.getEmail();
+        String nickname = kakaoUserInfo.getNickname();
+        String profileImageUrl = kakaoUserInfo.getProfileImageUrl();
+
+        // 2) 소셜 계정 존재 여부 확인
+        SocialAccount socialAccount =
+                socialAccountRepository.findByProviderAndProviderUserId("KAKAO", kakaoId.toString())
+                        .orElse(null);
+
+        boolean isNewMember = false;
+        Member member;
+
+        if (socialAccount == null) {
+            // 처음 로그인하는 카카오 계정 → 회원 + 소셜 계정 생성
+            member = Member.createKakaoMember(email, nickname, profileImageUrl);
+            memberRepository.save(member);
+
+            socialAccount = SocialAccount.createKakaoAccount(kakaoId.toString(), member);
+            socialAccountRepository.save(socialAccount);
+
+            isNewMember = true;
+        } else {
+            // 기존 회원
+            member = socialAccount.getMember();
+        }
+
+        // 3) 응답 DTO 생성 (필요하면 JWT 로직 추가)
+        return KakaoLoginResponse.of(member, isNewMember);
     }
 }

--- a/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import plango.auth.application.dto.request.KakaoLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.auth.application.mapper.KakaoAuthMapper;
 import plango.auth.domain.entity.SocialAccount;
 import plango.auth.domain.repository.SocialAccountRepository;
 import plango.auth.domain.service.KakaoAuthService;
@@ -16,45 +17,53 @@ import plango.member.domain.repository.MemberRepository;
 @RequiredArgsConstructor
 public class KakaoLoginUseCase {
 
+    private static final String KAKAO_PROVIDER = "KAKAO";
+
     private final KakaoAuthService kakaoAuthService;
     private final MemberRepository memberRepository;
     private final SocialAccountRepository socialAccountRepository;
 
     @Transactional
     public KakaoLoginResponse execute(KakaoLoginRequest request) {
-
-        // 1) 인가 코드 → 카카오 유저 정보 조회
+        // 1) 인가 코드로 카카오 사용자 정보 조회
         KakaoUserInfo kakaoUserInfo =
-                kakaoAuthService.getUserInfoByAuthorizationCode(request.getAuthorizationCode());
+                kakaoAuthService.getUserInfoByAuthorizationCode(request.authorizationCode());
 
         Long kakaoId = kakaoUserInfo.getId();
-        String email = kakaoUserInfo.getEmail();
-        String nickname = kakaoUserInfo.getNickname();
-        String profileImageUrl = kakaoUserInfo.getProfileImageUrl();
 
-        // 2) 소셜 계정 존재 여부 확인
-        SocialAccount socialAccount =
-                socialAccountRepository.findByProviderAndProviderUserId("KAKAO", kakaoId.toString())
-                        .orElse(null);
+        // 2) 기존 소셜 계정 존재 여부 확인
+        SocialAccount socialAccount = socialAccountRepository
+                .findByProviderAndProviderUserId(KAKAO_PROVIDER, kakaoId.toString())
+                .orElse(null);
 
-        boolean isNewMember = false;
         Member member;
+        boolean isNewMember;
 
         if (socialAccount == null) {
-            // 처음 로그인하는 카카오 계정 → 회원 + 소셜 계정 생성
-            member = Member.createKakaoMember(email, nickname, profileImageUrl);
-            memberRepository.save(member);
+            // 이메일 기준으로 기존 회원 여부 확인
+            String email = kakaoUserInfo.getEmail();
+            member = (email != null && !email.isBlank())
+                    ? memberRepository.findByEmail(email).orElse(null)
+                    : null;
 
+            // 완전 신규 회원이면 생성
+            if (member == null) {
+                member = KakaoAuthMapper.toMember(kakaoUserInfo);
+                memberRepository.save(member);
+            }
+
+            // 소셜 계정 연결
             socialAccount = SocialAccount.createKakaoAccount(kakaoId.toString(), member);
             socialAccountRepository.save(socialAccount);
 
             isNewMember = true;
         } else {
-            // 기존 회원
+            // 이미 소셜 계정이 연결된 기존 회원
             member = socialAccount.getMember();
+            isNewMember = false;
         }
 
-        // 3) 응답 DTO 생성 (필요하면 JWT 로직 추가)
-        return KakaoLoginResponse.of(member, isNewMember);
+        // 3) 응답 DTO 매핑 (추후 JWT 토큰 추가 가능)
+        return KakaoAuthMapper.toKakaoLoginResponse(member, isNewMember);
     }
 }

--- a/src/main/java/plango/auth/domain/entity/SocialAccount.java
+++ b/src/main/java/plango/auth/domain/entity/SocialAccount.java
@@ -9,6 +9,7 @@ import plango.member.domain.entity.Member;
 
 @Getter
 @Entity
+@Table(name = "social_account")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SocialAccount extends BaseTimeEntity {
 
@@ -23,9 +24,10 @@ public class SocialAccount extends BaseTimeEntity {
     private String provider;
 
     /**
-     * 제공자 쪽의 고유 사용자 ID (예: 카카오 id)
+     * 제공자 쪽의 고유 사용자 ID
+     *  - DB 컬럼명: provider_uid
      */
-    @Column(nullable = false, length = 100)
+    @Column(name = "provider_uid", nullable = false, length = 100)
     private String providerUserId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/plango/auth/domain/entity/SocialAccount.java
+++ b/src/main/java/plango/auth/domain/entity/SocialAccount.java
@@ -1,39 +1,48 @@
 package plango.auth.domain.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
-import plango.member.domain.entity.Member;
 import plango.global.common.entity.BaseTimeEntity;
+import plango.member.domain.entity.Member;
 
 @Getter
-@SuperBuilder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "social_account")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SocialAccount extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /**
+     * 소셜 로그인 제공자 (예: KAKAO, GOOGLE 등)
+     */
     @Column(nullable = false, length = 20)
     private String provider;
 
-    @Column(name = "provider_uid", nullable = false, length = 100, unique = true)
-    private String providerUid;
+    /**
+     * 제공자 쪽의 고유 사용자 ID (예: 카카오 id)
+     */
+    @Column(nullable = false, length = 100)
+    private String providerUserId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    // ===== 연관관계 편의 메서드 =====
+    private void setMember(Member member) {
+        this.member = member;
+    }
+
+    // ===== 정적 팩토리 메서드 =====
+    public static SocialAccount createKakaoAccount(String providerUserId, Member member) {
+        SocialAccount socialAccount = new SocialAccount();
+        socialAccount.provider = "KAKAO";
+        socialAccount.providerUserId = providerUserId;
+        socialAccount.setMember(member);
+        return socialAccount;
+    }
 }

--- a/src/main/java/plango/auth/domain/entity/SocialAccount.java
+++ b/src/main/java/plango/auth/domain/entity/SocialAccount.java
@@ -1,6 +1,14 @@
 package plango.auth.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,16 +25,9 @@ public class SocialAccount extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /**
-     * 소셜 로그인 제공자 (예: KAKAO, GOOGLE 등)
-     */
-    @Column(nullable = false, length = 20)
+    @Column(name = "provider", nullable = false, length = 20)
     private String provider;
 
-    /**
-     * 제공자 쪽의 고유 사용자 ID
-     *  - DB 컬럼명: provider_uid
-     */
     @Column(name = "provider_uid", nullable = false, length = 100)
     private String providerUserId;
 

--- a/src/main/java/plango/auth/domain/repository/SocialAccountRepository.java
+++ b/src/main/java/plango/auth/domain/repository/SocialAccountRepository.java
@@ -1,10 +1,11 @@
 package plango.auth.domain.repository;
 
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import plango.auth.domain.entity.SocialAccount;
 
+import java.util.Optional;
+
 public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
 
-    Optional<SocialAccount> findByProviderAndProviderUid(String provider, String providerUid);
+    Optional<SocialAccount> findByProviderAndProviderUserId(String provider, String providerUserId);
 }

--- a/src/main/java/plango/auth/domain/service/KakaoAuthService.java
+++ b/src/main/java/plango/auth/domain/service/KakaoAuthService.java
@@ -3,48 +3,41 @@ package plango.auth.domain.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import plango.auth.application.dto.response.KakaoTokenResponse;
-import plango.auth.application.dto.response.KakaoUserInfo;
+import plango.auth.application.dto.response.KakaoUserInfoResponse;
+import plango.global.common.exception.BusinessException;
+import plango.global.common.exception.ErrorCode;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoAuthService {
 
-    private final RestTemplate restTemplate;
-
-    @Value("${kakao.client-id}")
-    private String clientId;
-
-    @Value("${kakao.client-secret:}")
-    private String clientSecret;
-
-    @Value("${kakao.redirect-uri}")
-    private String redirectUri;
-
     private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
 
-    /**
-     * 인가 코드로 카카오 access token 발급 후, 해당 토큰으로 유저 정보 조회
-     */
-    public KakaoUserInfo getUserInfoByAuthorizationCode(String authorizationCode) {
-        KakaoTokenResponse tokenResponse = fetchAccessToken(authorizationCode);
+    private final RestTemplate restTemplate;
 
-        String accessToken = tokenResponse.getAccessToken();
-        if (accessToken == null || accessToken.isBlank()) {
-            throw new IllegalStateException("카카오 access token 발급에 실패했습니다.");
-        }
+    @Value("${oauth2.kakao.client-id}")
+    private String clientId;
 
-        return fetchUserInfo(accessToken);
+    @Value("${oauth2.kakao.redirect-uri}")
+    private String redirectUri;
+
+    public KakaoUserInfoResponse getUserInfoByAuthorizationCode(String authorizationCode) {
+        KakaoTokenResponse tokenResponse = getToken(authorizationCode);
+        return fetchUserInfo(tokenResponse.accessToken());
     }
 
-    private KakaoTokenResponse fetchAccessToken(String authorizationCode) {
+    private KakaoTokenResponse getToken(String authorizationCode) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
@@ -53,11 +46,9 @@ public class KakaoAuthService {
         params.add("client_id", clientId);
         params.add("redirect_uri", redirectUri);
         params.add("code", authorizationCode);
-        if (clientSecret != null && !clientSecret.isBlank()) {
-            params.add("client_secret", clientSecret);
-        }
 
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        HttpEntity<MultiValueMap<String, String>> request =
+                new HttpEntity<>(params, headers);
 
         ResponseEntity<KakaoTokenResponse> response =
                 restTemplate.postForEntity(TOKEN_URL, request, KakaoTokenResponse.class);
@@ -65,28 +56,38 @@ public class KakaoAuthService {
         if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
             log.warn("카카오 토큰 발급 실패. status={}, body={}",
                     response.getStatusCode(), response.getBody());
-            throw new IllegalStateException("카카오 토큰 발급 요청에 실패했습니다.");
+
+            ErrorCode errorCode = selectErrorCode(response.getStatusCode().value());
+            throw new BusinessException(errorCode.getStatusCode(), errorCode.getMessage());
         }
 
         return response.getBody();
     }
 
-    private KakaoUserInfo fetchUserInfo(String accessToken) {
+    private KakaoUserInfoResponse fetchUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         HttpEntity<Void> request = new HttpEntity<>(headers);
 
-        ResponseEntity<KakaoUserInfo> response =
-                restTemplate.postForEntity(USER_INFO_URL, request, KakaoUserInfo.class);
+        ResponseEntity<KakaoUserInfoResponse> response =
+                restTemplate.postForEntity(USER_INFO_URL, request, KakaoUserInfoResponse.class);
 
         if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
             log.warn("카카오 사용자 정보 조회 실패. status={}, body={}",
                     response.getStatusCode(), response.getBody());
-            throw new IllegalStateException("카카오 사용자 정보 조회에 실패했습니다.");
+
+            ErrorCode errorCode = selectErrorCode(response.getStatusCode().value());
+            throw new BusinessException(errorCode.getStatusCode(), errorCode.getMessage());
         }
 
         return response.getBody();
+    }
+
+    private ErrorCode selectErrorCode(int statusCode) {
+        if (statusCode == 401) {
+            return ErrorCode.KAKAO_INVALID_TOKEN;
+        }
+        return ErrorCode.KAKAO_SERVER_ERROR;
     }
 }

--- a/src/main/java/plango/auth/domain/service/KakaoAuthService.java
+++ b/src/main/java/plango/auth/domain/service/KakaoAuthService.java
@@ -1,152 +1,92 @@
 package plango.auth.domain.service;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClientException;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import plango.auth.application.dto.response.KakaoLoginResponse;
-import plango.member.domain.entity.Member;
-import plango.auth.domain.entity.SocialAccount;
-import plango.member.domain.repository.MemberRepository;
-import plango.auth.domain.repository.SocialAccountRepository;
-import plango.global.common.exception.BusinessException;
-import plango.global.common.exception.ErrorCode;
+import plango.auth.application.dto.response.KakaoTokenResponse;
+import plango.auth.application.dto.response.KakaoUserInfo;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class KakaoAuthService {
 
-    private static final String KAKAO_PROVIDER = "KAKAO";
-    private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
-
     private final RestTemplate restTemplate;
-    private final MemberRepository memberRepository;
-    private final SocialAccountRepository socialAccountRepository;
 
-    public KakaoLoginResponse login(String accessToken) {
-        KakaoUserResponse kakaoUserResponse = requestKakaoUser(accessToken);
+    @Value("${kakao.client-id}")
+    private String clientId;
 
-        Long kakaoId = kakaoUserResponse.getId();
-        KakaoUserResponse.KakaoAccount account = kakaoUserResponse.getKakaoAccount();
+    @Value("${kakao.client-secret:}")
+    private String clientSecret;
 
-        String email = account != null ? account.getEmail() : null;
-        String nickname = account != null && account.getProfile() != null
-                ? account.getProfile().getNickname()
-                : "카카오사용자";
-        String profileImageUrl = account != null && account.getProfile() != null
-                ? account.getProfile().getProfileImageUrl()
-                : null;
+    @Value("${kakao.redirect-uri}")
+    private String redirectUri;
 
-        String providerUid = String.valueOf(kakaoId);
+    private static final String TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
 
-        SocialAccount socialAccount = socialAccountRepository
-                .findByProviderAndProviderUid(KAKAO_PROVIDER, providerUid)
-                .orElseGet(() -> createMemberAndSocialAccount(providerUid, email, nickname, profileImageUrl));
+    /**
+     * 인가 코드로 카카오 access token 발급 후, 해당 토큰으로 유저 정보 조회
+     */
+    public KakaoUserInfo getUserInfoByAuthorizationCode(String authorizationCode) {
+        KakaoTokenResponse tokenResponse = fetchAccessToken(authorizationCode);
 
-        Member member = socialAccount.getMember();
+        String accessToken = tokenResponse.getAccessToken();
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalStateException("카카오 access token 발급에 실패했습니다.");
+        }
 
-        return KakaoLoginResponse.builder()
-                .memberId(member.getId())
-                .email(member.getEmail())
-                .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
-                .build();
+        return fetchUserInfo(accessToken);
     }
 
-    private KakaoUserResponse requestKakaoUser(String accessToken) {
+    private KakaoTokenResponse fetchAccessToken(String authorizationCode) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", authorizationCode);
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            params.add("client_secret", clientSecret);
+        }
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        ResponseEntity<KakaoTokenResponse> response =
+                restTemplate.postForEntity(TOKEN_URL, request, KakaoTokenResponse.class);
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            log.warn("카카오 토큰 발급 실패. status={}, body={}",
+                    response.getStatusCode(), response.getBody());
+            throw new IllegalStateException("카카오 토큰 발급 요청에 실패했습니다.");
+        }
+
+        return response.getBody();
+    }
+
+    private KakaoUserInfo fetchUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        HttpEntity<Void> entity = new HttpEntity<>(headers);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
 
-        try {
-            ResponseEntity<KakaoUserResponse> response = restTemplate.exchange(
-                    KAKAO_USER_INFO_URL,
-                    HttpMethod.GET,
-                    entity,
-                    KakaoUserResponse.class
-            );
+        ResponseEntity<KakaoUserInfo> response =
+                restTemplate.postForEntity(USER_INFO_URL, request, KakaoUserInfo.class);
 
-            if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
-                throw new BusinessException(
-                        ErrorCode.KAKAO_INVALID_TOKEN.getStatusCode(),
-                        ErrorCode.KAKAO_INVALID_TOKEN.getMessage()
-                );
-            }
-
-            return response.getBody();
-        } catch (HttpClientErrorException e) {
-            throw new BusinessException(
-                    ErrorCode.KAKAO_INVALID_TOKEN.getStatusCode(),
-                    ErrorCode.KAKAO_INVALID_TOKEN.getMessage()
-            );
-        } catch (RestClientException e) {
-            throw new BusinessException(
-                    ErrorCode.KAKAO_SERVER_ERROR.getStatusCode(),
-                    ErrorCode.KAKAO_SERVER_ERROR.getMessage()
-            );
-        }
-    }
-
-    private SocialAccount createMemberAndSocialAccount(
-            String providerUid,
-            String email,
-            String nickname,
-            String profileImageUrl
-    ) {
-        Member member = Member.builder()
-                .email(email)
-                .password(null)
-                .nickname(nickname)
-                .profileImageUrl(profileImageUrl)
-                .build();
-
-        Member savedMember = memberRepository.save(member);
-
-        SocialAccount socialAccount = SocialAccount.builder()
-                .provider(KAKAO_PROVIDER)
-                .providerUid(providerUid)
-                .member(savedMember)
-                .build();
-
-        return socialAccountRepository.save(socialAccount);
-    }
-
-    @Getter
-    @Setter
-    private static class KakaoUserResponse {
-
-        private Long id;
-
-        @JsonProperty("kakao_account")
-        private KakaoAccount kakaoAccount;
-
-        @Getter
-        @Setter
-        private static class KakaoAccount {
-
-            private String email;
-            private Profile profile;
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            log.warn("카카오 사용자 정보 조회 실패. status={}, body={}",
+                    response.getStatusCode(), response.getBody());
+            throw new IllegalStateException("카카오 사용자 정보 조회에 실패했습니다.");
         }
 
-        @Getter
-        @Setter
-        private static class Profile {
-
-            private String nickname;
-
-            @JsonProperty("profile_image_url")
-            private String profileImageUrl;
-        }
+        return response.getBody();
     }
 }

--- a/src/main/java/plango/auth/domain/service/SocialAccountService.java
+++ b/src/main/java/plango/auth/domain/service/SocialAccountService.java
@@ -1,0 +1,30 @@
+package plango.auth.domain.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.domain.entity.SocialAccount;
+import plango.auth.domain.repository.SocialAccountRepository;
+import plango.member.domain.entity.Member;
+
+@Service
+@RequiredArgsConstructor
+public class SocialAccountService {
+
+    private final SocialAccountRepository socialAccountRepository;
+
+    @Transactional(readOnly = true)
+    public Optional<SocialAccount> findByProviderAndProviderUserId(
+            String provider,
+            String providerUserId
+    ) {
+        return socialAccountRepository.findByProviderAndProviderUserId(provider, providerUserId);
+    }
+
+    @Transactional
+    public SocialAccount createAndSaveKakaoAccount(String providerUserId, Member member) {
+        SocialAccount socialAccount = SocialAccount.createKakaoAccount(providerUserId, member);
+        return socialAccountRepository.save(socialAccount);
+    }
+}

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -23,7 +23,7 @@ public class AuthController {
     ) {
         KakaoLoginResponse response = kakaoLoginUseCase.execute(request);
         return ResponseEntity.ok(
-                CommonResponse.success(ResponseMessage.KAKAO_LOGIN_SUCCESS, response)
+                CommonResponse.success(ResponseMessage.SUCCESS, response)
         );
     }
 }

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -1,12 +1,9 @@
 package plango.auth.presentation;
 
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 import plango.auth.application.dto.request.KakaoLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.usecase.KakaoLoginUseCase;
@@ -14,21 +11,19 @@ import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
     private final KakaoLoginUseCase kakaoLoginUseCase;
 
-    @Operation(summary = "카카오 로그인", description = "카카오 액세스 토큰으로 로그인합니다.")
-    @PostMapping("/kakao")
-    public CommonResponse<KakaoLoginResponse> kakaoLogin(
-            @Valid @RequestBody KakaoLoginRequest request
+    @PostMapping("/kakao/login")
+    public ResponseEntity<CommonResponse<KakaoLoginResponse>> kakaoLogin(
+            @RequestBody @Valid KakaoLoginRequest request
     ) {
         KakaoLoginResponse response = kakaoLoginUseCase.execute(request);
-        return CommonResponse.createSuccess(
-                ResponseMessage.KAKAO_LOGIN_SUCCESS.getMessage(),
-                response
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.KAKAO_LOGIN_SUCCESS, response)
         );
     }
 }

--- a/src/main/java/plango/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/plango/global/common/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package plango.global.common.exception;
 
 import com.fasterxml.jackson.databind.JsonMappingException.Reference;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import plango.global.common.response.CommonResponse; // ← PlanGo 공통응답 경로로 변경
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -12,6 +11,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import plango.global.common.response.CommonResponse;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<CommonResponse<Void>> handle(BusinessException ex) {
         CommonResponse<Void> response =
-                CommonResponse.createFailure(ex.getStatusCode(), ex.getMessage());
+                CommonResponse.fail(ex.getStatusCode(), ex.getMessage());
 
         log.warn("BusinessException: ", ex);
         log.warn(LOG_FORMAT, ex.getClass().getSimpleName(), ex.getStatusCode(), ex.getMessage());
@@ -37,22 +37,22 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<List<BindExceptionResponse>>> handle(BindException ex) {
         List<BindExceptionResponse> exceptionResponses = new ArrayList<>();
 
-        ex.getBindingResult().getFieldErrors().forEach(fieldError -> {
-            exceptionResponses.add(BindExceptionResponse.builder()
-                    .message(fieldError.getDefaultMessage())
-                    .data(fieldError.getRejectedValue())
-                    .build());
-        });
+        ex.getBindingResult().getFieldErrors().forEach(fieldError ->
+                exceptionResponses.add(BindExceptionResponse.builder()
+                        .message(fieldError.getDefaultMessage())
+                        .data(fieldError.getRejectedValue())
+                        .build())
+        );
 
-        CommonResponse<List<BindExceptionResponse>> response = CommonResponse.createFailure(
+        CommonResponse<List<BindExceptionResponse>> response = CommonResponse.fail(
                 ErrorCode.BIND_EXCEPTION.getStatusCode(),
                 ErrorCode.BIND_EXCEPTION.getMessage(),
                 exceptionResponses
         );
 
-        log.warn("BindException: ", ex);
+        log.warn("BindException");
         log.warn(LOG_FORMAT, ex.getClass().getSimpleName(),
-                ErrorCode.BIND_EXCEPTION.getStatusCode(), exceptionResponses);
+                ErrorCode.BIND_EXCEPTION.getStatusCode(), ex.getMessage());
 
         return ResponseEntity
                 .status(ErrorCode.BIND_EXCEPTION.getStatusCode())
@@ -61,8 +61,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<CommonResponse<Void>> handle(MethodArgumentTypeMismatchException ex) {
-
-        CommonResponse<Void> response = CommonResponse.createFailure(
+        CommonResponse<Void> response = CommonResponse.fail(
                 ErrorCode.ARGUMENT_TYPE_MISMATCH_EXCEPTION.getStatusCode(),
                 ErrorCode.ARGUMENT_TYPE_MISMATCH_EXCEPTION.getFormatted(ex.getName())
         );
@@ -78,26 +77,27 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<List<ArgumentNotValidExceptionResponse>>> handleValidation(
-            MethodArgumentNotValidException ex) {
+            MethodArgumentNotValidException ex
+    ) {
+        List<ArgumentNotValidExceptionResponse> exceptionResponses = new ArrayList<>();
 
-        List<ArgumentNotValidExceptionResponse> exceptionResponses = ex.getBindingResult()
-                .getFieldErrors().stream()
-                .map(error -> ArgumentNotValidExceptionResponse.builder()
-                        .field(error.getField())
-                        .message(error.getDefaultMessage())
-                        .data(error.getRejectedValue())
+        ex.getBindingResult().getFieldErrors().forEach(fieldError ->
+                exceptionResponses.add(ArgumentNotValidExceptionResponse.builder()
+                        .field(fieldError.getField())
+                        .message(fieldError.getDefaultMessage())
+                        .data(fieldError.getRejectedValue())
                         .build())
-                .toList();
+        );
 
-        CommonResponse<List<ArgumentNotValidExceptionResponse>> response = CommonResponse.createFailure(
+        CommonResponse<List<ArgumentNotValidExceptionResponse>> response = CommonResponse.fail(
                 ErrorCode.ARGUMENT_NOT_VALID_EXCEPTION.getStatusCode(),
                 ErrorCode.ARGUMENT_NOT_VALID_EXCEPTION.getMessage(),
                 exceptionResponses
         );
 
-        log.warn("MethodArgumentNotValidException: ", ex);
+        log.warn("MethodArgumentNotValidException");
         log.warn(LOG_FORMAT, ex.getClass().getSimpleName(),
-                ErrorCode.ARGUMENT_NOT_VALID_EXCEPTION.getStatusCode(), exceptionResponses);
+                ErrorCode.ARGUMENT_NOT_VALID_EXCEPTION.getStatusCode(), ex.getMessage());
 
         return ResponseEntity
                 .status(ErrorCode.ARGUMENT_NOT_VALID_EXCEPTION.getStatusCode())
@@ -106,31 +106,33 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<CommonResponse<Void>> handle(HttpMessageNotReadableException ex) {
-        // DTO 필드 타입 불일치
+        // DTO 필드 타입 불일치 (MismatchedInputException)
         if (ex.getCause() instanceof MismatchedInputException mismatched) {
             String fieldName = null;
             for (Reference ref : mismatched.getPath()) {
-                fieldName = ref.getFieldName(); // 경로의 마지막 필드가 문제 필드
+                fieldName = ref.getFieldName(); // 경로의 마지막 필드명이 문제 필드
             }
 
             log.warn("MismatchedInputException");
             log.warn(LOG_FORMAT, ex.getClass().getSimpleName(),
                     ErrorCode.MISMATCHED_INPUT_EXCEPTION.getStatusCode(), ex.getMessage());
 
-            CommonResponse<Void> response = CommonResponse.createFailure(
+            CommonResponse<Void> response = CommonResponse.fail(
                     ErrorCode.MISMATCHED_INPUT_EXCEPTION.getStatusCode(),
                     ErrorCode.MISMATCHED_INPUT_EXCEPTION.getFormatted(fieldName)
             );
+
             return ResponseEntity
                     .status(ErrorCode.MISMATCHED_INPUT_EXCEPTION.getStatusCode())
                     .body(response);
         }
 
+        // 그 외 JSON 파싱 문제
         log.warn("HttpMessageNotReadableException");
         log.warn(LOG_FORMAT, ex.getClass().getSimpleName(),
                 ErrorCode.JSON_PARSE_EXCEPTION.getStatusCode(), ex.getMessage());
 
-        CommonResponse<Void> response = CommonResponse.createFailure(
+        CommonResponse<Void> response = CommonResponse.fail(
                 ErrorCode.JSON_PARSE_EXCEPTION.getStatusCode(),
                 ErrorCode.JSON_PARSE_EXCEPTION.getMessage()
         );
@@ -151,7 +153,7 @@ public class GlobalExceptionHandler {
         log.warn("기타 Exception: ", ex);
         log.warn(LOG_FORMAT, ex.getClass().getSimpleName(), statusCode, ex.getMessage());
 
-        CommonResponse<Void> response = CommonResponse.createFailure(statusCode, ex.getMessage());
+        CommonResponse<Void> response = CommonResponse.fail(statusCode, ex.getMessage());
 
         return ResponseEntity.status(statusCode).body(response);
     }

--- a/src/main/java/plango/global/common/response/CommonResponse.java
+++ b/src/main/java/plango/global/common/response/CommonResponse.java
@@ -1,9 +1,19 @@
 package plango.global.common.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+/**
+ * 모든 API 응답을 감싸는 공통 응답 객체
+ *  - code    : 비즈니스/HTTP 코드
+ *  - message : 응답 메시지
+ *  - data    : 실제 응답 데이터
+ */
 @Getter
+@Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class CommonResponse<T> {
 
@@ -11,19 +21,56 @@ public class CommonResponse<T> {
     private String message;
     private T data;
 
-    public static <T> CommonResponse<T> createSuccess(String message) {
-        return new CommonResponse<>(200, message, null);
+    // =======================
+    // 성공 응답
+    // =======================
+
+    /** ResponseMessage 기반 성공 응답 */
+    public static <T> CommonResponse<T> success(ResponseMessage message, T data) {
+        return CommonResponse.<T>builder()
+                .code(message.getCode())
+                .message(message.getMessage())
+                .data(data)
+                .build();
     }
 
-    public static <T> CommonResponse<T> createSuccess(String message, T data) {
-        return new CommonResponse<>(200, message, data);
+    /** 임의 메시지 기반 성공 응답 */
+    public static <T> CommonResponse<T> success(String message, T data) {
+        return CommonResponse.<T>builder()
+                .code(0)
+                .message(message)
+                .data(data)
+                .build();
     }
 
-    public static <T> CommonResponse<T> createFailure(int statusCode, String message) {
-        return new CommonResponse<>(statusCode, message, null);
+    // =======================
+    // 실패 응답 (기존 + createFailure 추가)
+    // =======================
+
+    /** 간단 실패 응답 (code + message, data 는 null) */
+    public static <T> CommonResponse<T> fail(ResponseMessage message) {
+        return CommonResponse.<T>builder()
+                .code(message.getCode())
+                .message(message.getMessage())
+                .data(null)
+                .build();
     }
 
-    public static <T> CommonResponse<T> createFailure(int statusCode, String message, T data) {
-        return new CommonResponse<>(statusCode, message, data);
+    /** GlobalExceptionHandler 에서 사용하는 실패 응답 (data 없음) */
+    public static <T> CommonResponse<T> createFailure(int code, String message) {
+        return CommonResponse.<T>builder()
+                .code(code)
+                .message(message)
+                .data(null)
+                .build();
+    }
+
+    /** GlobalExceptionHandler 에서 사용하는 실패 응답 (data 포함) */
+    public static <T> CommonResponse<T> createFailure(int code, String message, T data) {
+        return CommonResponse.<T>builder()
+                .code(code)
+                .message(message)
+                .data(data)
+                .build();
     }
 }

--- a/src/main/java/plango/global/common/response/CommonResponse.java
+++ b/src/main/java/plango/global/common/response/CommonResponse.java
@@ -5,12 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-/**
- * 모든 API 응답을 감싸는 공통 응답 객체
- *  - code    : 비즈니스/HTTP 코드
- *  - message : 응답 메시지
- *  - data    : 실제 응답 데이터
- */
 @Getter
 @Builder
 @NoArgsConstructor
@@ -21,11 +15,8 @@ public class CommonResponse<T> {
     private String message;
     private T data;
 
-    // =======================
-    // 성공 응답
-    // =======================
 
-    /** ResponseMessage 기반 성공 응답 */
+    /** 공통 ResponseMessage 기반 성공 응답 */
     public static <T> CommonResponse<T> success(ResponseMessage message, T data) {
         return CommonResponse.<T>builder()
                 .code(message.getCode())
@@ -43,11 +34,17 @@ public class CommonResponse<T> {
                 .build();
     }
 
-    // =======================
-    // 실패 응답 (기존 + createFailure 추가)
-    // =======================
+    /** ResponseMessage 기반 성공 응답 (기존 createSuccess 호출 호환용) */
+    public static <T> CommonResponse<T> createSuccess(ResponseMessage message, T data) {
+        return success(message, data);
+    }
 
-    /** 간단 실패 응답 (code + message, data 는 null) */
+    /** 문자열 메시지 기반 성공 응답 (기존 createSuccess 호출 호환용) */
+    public static <T> CommonResponse<T> createSuccess(String message, T data) {
+        return success(message, data);
+    }
+
+    /** ResponseMessage 기반 실패 응답 (data 는 null) */
     public static <T> CommonResponse<T> fail(ResponseMessage message) {
         return CommonResponse.<T>builder()
                 .code(message.getCode())
@@ -56,8 +53,8 @@ public class CommonResponse<T> {
                 .build();
     }
 
-    /** GlobalExceptionHandler 에서 사용하는 실패 응답 (data 없음) */
-    public static <T> CommonResponse<T> createFailure(int code, String message) {
+    /** 코드 + 메시지 기반 실패 응답 (data 없음, GlobalExceptionHandler 등에서 사용) */
+    public static <T> CommonResponse<T> fail(int code, String message) {
         return CommonResponse.<T>builder()
                 .code(code)
                 .message(message)
@@ -65,8 +62,8 @@ public class CommonResponse<T> {
                 .build();
     }
 
-    /** GlobalExceptionHandler 에서 사용하는 실패 응답 (data 포함) */
-    public static <T> CommonResponse<T> createFailure(int code, String message, T data) {
+    /** 코드 + 메시지 + data 기반 실패 응답 */
+    public static <T> CommonResponse<T> fail(int code, String message, T data) {
         return CommonResponse.<T>builder()
                 .code(code)
                 .message(message)

--- a/src/main/java/plango/global/common/response/CommonResponse.java
+++ b/src/main/java/plango/global/common/response/CommonResponse.java
@@ -15,7 +15,6 @@ public class CommonResponse<T> {
     private String message;
     private T data;
 
-
     /** 공통 ResponseMessage 기반 성공 응답 */
     public static <T> CommonResponse<T> success(ResponseMessage message, T data) {
         return CommonResponse.<T>builder()
@@ -69,5 +68,15 @@ public class CommonResponse<T> {
                 .message(message)
                 .data(data)
                 .build();
+    }
+
+    /** 기존 createFailure(int, String) 호출 호환용 */
+    public static <T> CommonResponse<T> createFailure(int code, String message) {
+        return fail(code, message);
+    }
+
+    /** 기존 createFailure(int, String, T) 호출 호환용 */
+    public static <T> CommonResponse<T> createFailure(int code, String message, T data) {
+        return fail(code, message, data);
     }
 }

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -3,11 +3,19 @@ package plango.global.common.response;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * 비즈니스 응답 코드 & 메시지 정의
+ */
 @Getter
 @RequiredArgsConstructor
 public enum ResponseMessage {
 
-    KAKAO_LOGIN_SUCCESS("카카오 로그인에 성공했습니다.");
+    // ===== 공통 =====
+    SUCCESS(0, "성공"),
 
+    // ===== 인증 / 카카오 로그인 =====
+    KAKAO_LOGIN_SUCCESS(1000, "카카오 로그인에 성공했습니다.");
+
+    private final int code;
     private final String message;
 }

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -3,18 +3,12 @@ package plango.global.common.response;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-/**
- * 비즈니스 응답 코드 & 메시지 정의
- */
 @Getter
 @RequiredArgsConstructor
 public enum ResponseMessage {
 
     // ===== 공통 =====
-    SUCCESS(0, "성공"),
-
-    // ===== 인증 / 카카오 로그인 =====
-    KAKAO_LOGIN_SUCCESS(1000, "카카오 로그인에 성공했습니다.");
+    SUCCESS(0, "성공");
 
     private final int code;
     private final String message;

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -1,6 +1,10 @@
 package plango.member.domain.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,10 +19,9 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(length = 100, nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false, length = 50)
     private String nickname;
 
     @Column(length = 255)

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -1,37 +1,35 @@
 package plango.member.domain.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 import plango.global.common.entity.BaseTimeEntity;
 
 @Getter
-@SuperBuilder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name = "member")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(unique = true, length = 100)
+    @Column(nullable = false, unique = true, length = 100)
     private String email;
-
-    @Column(length = 200)
-    private String password;
 
     @Column(nullable = false, length = 50)
     private String nickname;
 
-    @Column(name = "profile_image_url", length = 255)
+    @Column(length = 255)
     private String profileImageUrl;
+
+    // ===== 정적 팩토리 메서드 =====
+    public static Member createKakaoMember(String email, String nickname, String profileImageUrl) {
+        Member member = new Member();
+        member.email = email;
+        member.nickname = nickname;
+        member.profileImageUrl = profileImageUrl;
+        return member;
+    }
 }

--- a/src/main/java/plango/member/domain/service/MemberService.java
+++ b/src/main/java/plango/member/domain/service/MemberService.java
@@ -1,0 +1,25 @@
+package plango.member.domain.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.member.domain.entity.Member;
+import plango.member.domain.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional(readOnly = true)
+    public Optional<Member> findByEmail(String email) {
+        return memberRepository.findByEmail(email);
+    }
+
+    @Transactional
+    public Member save(Member member) {
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -48,13 +48,13 @@ security:
   aes:
     key: ${AES_KEY:}
 
-preview:
-  api:
-    url: ${PREVIEW_API_URL:http://localhost:3000}
+  preview:
+    api:
+      url: ${PREVIEW_API_URL}
 
-kakao:
-  client-id: "6ecbd75cc6c1f3a8819f66e5698ee294"
-  client-secret: ""
-  redirect-uri: "http://ceprj2.gachon.ac.kr:65028/login/oauth2/code/kakao"
+  oauth2:
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID:}
+      redirect-uri: ${KAKAO_REDIRECT_URI:}
 
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -55,5 +55,6 @@ preview:
 kakao:
   client-id: "6ecbd75cc6c1f3a8819f66e5698ee294"
   client-secret: ""
-  redirect-uri: "http://ceprj2.gachon.ac.kr:8080/login/oauth2/code/kakao"
+  redirect-uri: "http://ceprj2.gachon.ac.kr:65028/login/oauth2/code/kakao"
+
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -55,5 +55,5 @@ preview:
 kakao:
   client-id: "6ecbd75cc6c1f3a8819f66e5698ee294"
   client-secret: ""
-  redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+  redirect-uri: "http://ceprj2.gachon.ac.kr:8080/login/oauth2/code/kakao"
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -51,3 +51,9 @@ security:
 preview:
   api:
     url: ${PREVIEW_API_URL:http://localhost:3000}
+
+kakao:
+  client-id: "6ecbd75cc6c1f3a8819f66e5698ee294"
+  client-secret: ""
+  redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #20 

## 🔎 작업 내용

- 카카오 OAuth2 인증 플로우 구현
- 레코드(record) 기반 DTO 리팩토링
- Mapper 분리 (컨벤션 준수)
- UseCase 구조 정리
- 리다이렉트 URI 및 팀 서버 포트 반영
- 학과 서버 배포 및 통합 테스트 완료

<br>


## 📌 참고 사항

- 집중 리뷰 <!--(선택 사항)-->
    - DTO를 record로 변경한 부분이 팀 컨벤션에 적합한지 확인 부탁드립니다.
    - Mapper 분리 구조(KakaoAuthMapper)가 서비스 전체 구조와 잘 맞는지 검토 부탁드립니다.
    - UseCase 로직 책임 분배가 적절한지 피드백 부탁드립니다.
- 기타 안내 사항 <!--(선택 사항)-->
    - 현재는 인가 코드만 받아서 로그인하는 구조이며, JWT 발급/세션 처리 등은 이후 PR에서 추가 예정입니다.
    - 카카오 access token은 서버에서 자동 발급하도록 구현되어 Swagger에서는 인가 코드만 입력하면 됩니다.
<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  
<img width="1419" height="909" alt="image" src="https://github.com/user-attachments/assets/195f78b3-ae52-4b20-ac77-b07d2b717be7" />


<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수