### PR TITLE
Feat/#13/유저-일반 로그인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment / Secrets ###
 .env
+.env.*

--- a/src/main/java/plango/auth/application/dto/request/MemberLoginRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/MemberLoginRequest.java
@@ -1,0 +1,12 @@
+package plango.auth.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MemberLoginRequest(
+        @NotBlank(message = "아이디는 필수입니다.")
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/main/java/plango/auth/application/usecase/MemberLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/MemberLoginUseCase.java
@@ -1,0 +1,38 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.request.MemberLoginRequest;
+import plango.auth.application.dto.response.KakaoLoginResponse;
+import plango.auth.application.mapper.KakaoAuthMapper;
+import plango.global.common.exception.BusinessException;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberService;
+
+@Service
+@RequiredArgsConstructor
+public class MemberLoginUseCase {
+
+    private final MemberService memberService;
+
+    @Transactional(readOnly = true)
+    public KakaoLoginResponse execute(MemberLoginRequest request) {
+        Member member = memberService.findByEmail(request.loginId())
+                .orElseThrow(() -> new BusinessException(
+                        HttpStatus.UNAUTHORIZED.value(),
+                        "아이디 또는 비밀번호가 일치하지 않습니다."
+                ));
+
+        if (!member.getPassword().equals(request.password())) {
+            throw new BusinessException(
+                    HttpStatus.UNAUTHORIZED.value(),
+                    "아이디 또는 비밀번호가 일치하지 않습니다."
+            );
+        }
+
+        // 일반 로그인은 항상 기존 회원 → newMember = false
+        return KakaoAuthMapper.toKakaoLoginResponse(member, false);
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/MemberLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/MemberLoginUseCase.java
@@ -1,38 +1,26 @@
 package plango.auth.application.usecase;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plango.auth.application.dto.request.MemberLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.mapper.KakaoAuthMapper;
-import plango.global.common.exception.BusinessException;
 import plango.member.domain.entity.Member;
 import plango.member.domain.service.MemberService;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberLoginUseCase {
 
     private final MemberService memberService;
 
-    @Transactional(readOnly = true)
     public KakaoLoginResponse execute(MemberLoginRequest request) {
-        Member member = memberService.findByEmail(request.loginId())
-                .orElseThrow(() -> new BusinessException(
-                        HttpStatus.UNAUTHORIZED.value(),
-                        "아이디 또는 비밀번호가 일치하지 않습니다."
-                ));
+        // 비즈니스 로직은 Service에서 처리
+        Member member = memberService.loginByLoginId(request.loginId(), request.password());
 
-        if (!member.getPassword().equals(request.password())) {
-            throw new BusinessException(
-                    HttpStatus.UNAUTHORIZED.value(),
-                    "아이디 또는 비밀번호가 일치하지 않습니다."
-            );
-        }
-
-        // 일반 로그인은 항상 기존 회원 → newMember = false
+        // UseCase는 흐름 조합 + 응답 변환만 담당
         return KakaoAuthMapper.toKakaoLoginResponse(member, false);
     }
 }

--- a/src/main/java/plango/auth/application/usecase/MemberLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/MemberLoginUseCase.java
@@ -17,10 +17,7 @@ public class MemberLoginUseCase {
     private final MemberService memberService;
 
     public KakaoLoginResponse execute(MemberLoginRequest request) {
-        // 비즈니스 로직은 Service에서 처리
         Member member = memberService.loginByLoginId(request.loginId(), request.password());
-
-        // UseCase는 흐름 조합 + 응답 변환만 담당
         return KakaoAuthMapper.toKakaoLoginResponse(member, false);
     }
 }

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -1,22 +1,43 @@
 package plango.auth.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import plango.auth.application.dto.request.KakaoLoginRequest;
+import plango.auth.application.dto.request.MemberLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.usecase.KakaoLoginUseCase;
+import plango.auth.application.usecase.MemberLoginUseCase;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
+@Tag(name = "Auth", description = "인증 관련 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final KakaoLoginUseCase kakaoLoginUseCase;
+    private final MemberLoginUseCase memberLoginUseCase;
 
+    @Operation(summary = "일반 로그인", description = "아이디와 비밀번호로 로그인합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<CommonResponse<KakaoLoginResponse>> login(
+            @RequestBody @Valid MemberLoginRequest request
+    ) {
+        KakaoLoginResponse response = memberLoginUseCase.execute(request);
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS, response)
+        );
+    }
+
+    @Operation(summary = "카카오 로그인", description = "카카오 액세스 토큰으로 로그인합니다.")
     @PostMapping("/kakao/login")
     public ResponseEntity<CommonResponse<KakaoLoginResponse>> kakaoLogin(
             @RequestBody @Valid KakaoLoginRequest request

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -19,23 +19,32 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 100, nullable = false, unique = true)
+    // 일반 로그인용 아이디 (로그인 시 사용)
+    @Column(name = "login_id", nullable = false, unique = true, length = 50)
+    private String loginId;
+
+    @Column(nullable = false, unique = true, length = 100)
     private String email;
 
-    @Column(length = 200)
+    @Column(nullable = false, length = 200)
     private String password;
 
+    @Column(nullable = false, length = 50)
     private String nickname;
 
     @Column(length = 255)
     private String profileImageUrl;
 
     // ===== 정적 팩토리 메서드 =====
+    // 카카오 로그인으로 가입하는 회원 생성 시 사용
     public static Member createKakaoMember(String email, String nickname, String profileImageUrl) {
         Member member = new Member();
+        // 카카오 회원은 우선 loginId 를 email 과 동일하게 사용
+        member.loginId = email;
         member.email = email;
         member.nickname = nickname;
         member.profileImageUrl = profileImageUrl;
+        // 비밀번호는 아직 없음 (추후 일반 로그인 전환 시 별도 처리)
         return member;
     }
 }

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -22,6 +22,9 @@ public class Member extends BaseTimeEntity {
     @Column(length = 100, nullable = false, unique = true)
     private String email;
 
+    @Column(length = 200)
+    private String password;
+
     private String nickname;
 
     @Column(length = 255)

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -19,14 +19,13 @@ public class Member extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 일반 로그인용 아이디 (로그인 시 사용)
-    @Column(name = "login_id", nullable = false, unique = true, length = 50)
+    @Column(name = "login_id", unique = true, length = 50)
     private String loginId;
 
-    @Column(nullable = false, unique = true, length = 100)
+    @Column(unique = true, length = 100)
     private String email;
 
-    @Column(nullable = false, length = 200)
+    @Column(length = 200)
     private String password;
 
     @Column(nullable = false, length = 50)
@@ -35,16 +34,17 @@ public class Member extends BaseTimeEntity {
     @Column(length = 255)
     private String profileImageUrl;
 
-    // ===== 정적 팩토리 메서드 =====
-    // 카카오 로그인으로 가입하는 회원 생성 시 사용
-    public static Member createKakaoMember(String email, String nickname, String profileImageUrl) {
+
+    public static Member createKakaoMember(
+            String email,
+            String nickname,
+            String profileImageUrl
+    ) {
         Member member = new Member();
-        // 카카오 회원은 우선 loginId 를 email 과 동일하게 사용
-        member.loginId = email;
         member.email = email;
         member.nickname = nickname;
         member.profileImageUrl = profileImageUrl;
-        // 비밀번호는 아직 없음 (추후 일반 로그인 전환 시 별도 처리)
         return member;
     }
+
 }

--- a/src/main/java/plango/member/domain/repository/MemberRepository.java
+++ b/src/main/java/plango/member/domain/repository/MemberRepository.java
@@ -6,5 +6,7 @@ import plango.member.domain.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    Optional<Member> findByLoginId(String loginId);
+
     Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/plango/member/domain/service/MemberService.java
+++ b/src/main/java/plango/member/domain/service/MemberService.java
@@ -6,14 +6,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plango.member.domain.entity.Member;
 import plango.member.domain.repository.MemberRepository;
+import plango.member.exception.MemberErrorCode;
+import plango.member.exception.MemberException;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    @Transactional(readOnly = true)
+    public Optional<Member> findByLoginId(String loginId) {
+        return memberRepository.findByLoginId(loginId);
+    }
+
     public Optional<Member> findByEmail(String email) {
         return memberRepository.findByEmail(email);
     }
@@ -21,5 +27,24 @@ public class MemberService {
     @Transactional
     public Member save(Member member) {
         return memberRepository.save(member);
+    }
+
+    public Member loginByLoginId(String loginId, String rawPassword) {
+        Member member = memberRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_CREDENTIAL));
+
+        if (!isPasswordMatch(member, rawPassword)) {
+            throw new MemberException(MemberErrorCode.INVALID_MEMBER_CREDENTIAL);
+        }
+
+        return member;
+    }
+
+    private boolean isPasswordMatch(Member member, String rawPassword) {
+        if (member.getPassword() == null || rawPassword == null) {
+            return false;
+        }
+
+        return member.getPassword().equals(rawPassword);
     }
 }

--- a/src/main/java/plango/member/exception/MemberErrorCode.java
+++ b/src/main/java/plango/member/exception/MemberErrorCode.java
@@ -1,0 +1,19 @@
+package plango.member.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member not found"),
+    INVALID_MEMBER_STATUS(HttpStatus.BAD_REQUEST, "Invalid member status"),
+
+    // 아이디 또는 비밀번호가 틀린 경우
+    INVALID_MEMBER_CREDENTIAL(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/plango/member/exception/MemberException.java
+++ b/src/main/java/plango/member/exception/MemberException.java
@@ -1,0 +1,15 @@
+package plango.member.exception;
+
+import lombok.Getter;
+import plango.global.common.exception.BusinessException;
+
+@Getter
+public class MemberException extends BusinessException {
+
+    private final MemberErrorCode errorCode;
+
+    public MemberException(MemberErrorCode errorCode) {
+        super(errorCode.getStatus().value(), errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/resources/db/migration/V3__add_login_id_to_member.sql
+++ b/src/main/resources/db/migration/V3__add_login_id_to_member.sql
@@ -1,0 +1,15 @@
+-- 1) login_id 컬럼 추가 (기존 데이터 때문에 일단 NULL 허용으로 추가)
+ALTER TABLE member
+    ADD COLUMN login_id VARCHAR(50) NULL AFTER id;
+
+-- 2) 기존 회원들의 login_id를 email 기준으로 초기화
+UPDATE member
+SET login_id = email
+WHERE login_id IS NULL;
+
+-- 3) login_id NOT NULL + 고유 제약조건 부여
+ALTER TABLE member
+    MODIFY COLUMN login_id VARCHAR(50) NOT NULL;
+
+CREATE UNIQUE INDEX ux_member_login_id
+    ON member (login_id);

--- a/src/main/resources/db/migration/V4__make_login_id_nullable.sql
+++ b/src/main/resources/db/migration/V4__make_login_id_nullable.sql
@@ -1,0 +1,5 @@
+-- login_id 를 일반 로그인 전용 필드로 사용하기 위해
+-- 카카오 전용 회원에 대해서는 NULL 을 허용한다.
+
+ALTER TABLE member
+    MODIFY COLUMN login_id VARCHAR(50) NULL;


### PR DESCRIPTION
## ✨ 관련 이슈
- Resolved: #26 

## 🔎 작업 내용
- 일반 로그인 기능 추가 (아이디 + 비밀번호 기반)
- `MemberLoginRequest` DTO 생성
- `MemberLoginUseCase` 구현  
  - DB에서 email 기반으로 Member 조회  
  - 비밀번호 검증 로직 추가  
  - 로그인 성공 시 `KakaoLoginResponse` 포맷으로 응답 (newMember = false)
- `AuthController`에 `/api/auth/login` 엔드포인트 추가
- 멤버 엔티티(`Member`)에 password 필드 추가
- Swagger 명세 추가
- 서버/학과 DB에서 실제 Swagger UI 테스트 완료

<br>

## 📌 참고 사항
### 🔥 주의해야 할 점
- 현재 DB(`member` 테이블)에 **loginId(아이디) 컬럼이 존재하지 않음**  
  → 임시로 **loginId = email 컬럼으로 매핑**하여 로그인 처리함  
  → 이후 회원가입 구현 시 `login_id` 컬럼 추가 후 조회 로직 수정 필요  

### 📌 기타 안내 사항
- 기존 카카오 로그인 응답 구조(`KakaoLoginResponse`)를 그대로 재사용하여 API 일관성 유지
- 비밀번호는 현재 평문 비교
  → 추후 회원가입 구현 시 `BCryptPasswordEncoder`로 암호화 적용 예정



<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
<img width="556" height="321" alt="image" src="https://github.com/user-attachments/assets/d807dc02-8b38-4d9e-bb68-9a77fbe03ee0" />
<img width="1425" height="906" alt="image" src="https://github.com/user-attachments/assets/f85786e2-4f82-41ec-b594-c316161015f2" />
<img width="1420" height="825" alt="image" src="https://github.com/user-attachments/assets/41be7caa-2e26-4a59-acdb-ad74d4042084" />


<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수