### PR TITLE
Feat/#12/여행방생성

### DIFF
--- a/src/main/java/plango/member/domain/service/MemberGetService.java
+++ b/src/main/java/plango/member/domain/service/MemberGetService.java
@@ -1,0 +1,22 @@
+package plango.member.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.member.domain.entity.Member;
+import plango.member.domain.repository.MemberRepository;
+import plango.member.exception.MemberErrorCode;
+import plango.member.exception.MemberException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberGetService {
+
+    private final MemberRepository memberRepository;
+
+    public Member getById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/plango/member/exception/MemberErrorCode.java
+++ b/src/main/java/plango/member/exception/MemberErrorCode.java
@@ -9,22 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member not found"),
-    INVALID_MEMBER_STATUS(HttpStatus.BAD_REQUEST, "Invalid member status");
-
-    private final HttpStatus status;
-    private final String message;
-}
-package plango.member.exception;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-
-@Getter
-@RequiredArgsConstructor
-public enum MemberErrorCode {
-
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member not found"),
     INVALID_MEMBER_STATUS(HttpStatus.BAD_REQUEST, "Invalid member status"),
 
     // 아이디 또는 비밀번호가 틀린 경우
@@ -33,4 +17,3 @@ public enum MemberErrorCode {
     private final HttpStatus status;
     private final String message;
 }
-

--- a/src/main/java/plango/member/exception/MemberErrorCode.java
+++ b/src/main/java/plango/member/exception/MemberErrorCode.java
@@ -1,0 +1,16 @@
+package plango.member.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member not found"),
+    INVALID_MEMBER_STATUS(HttpStatus.BAD_REQUEST, "Invalid member status");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/plango/member/exception/MemberException.java
+++ b/src/main/java/plango/member/exception/MemberException.java
@@ -1,0 +1,15 @@
+package plango.member.exception;
+
+import lombok.Getter;
+import plango.global.common.exception.BusinessException;
+
+@Getter
+public class MemberException extends BusinessException {
+
+    private final MemberErrorCode errorCode;
+
+    public MemberException(MemberErrorCode errorCode) {
+        super(errorCode.getStatus().value(), errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/plango/member/exception/MemberException.java
+++ b/src/main/java/plango/member/exception/MemberException.java
@@ -14,19 +14,3 @@ public class MemberException extends BusinessException {
     }
 }
 
-package plango.member.exception;
-
-import lombok.Getter;
-import plango.global.common.exception.BusinessException;
-
-@Getter
-public class MemberException extends BusinessException {
-
-    private final MemberErrorCode errorCode;
-
-    public MemberException(MemberErrorCode errorCode) {
-        super(errorCode.getStatus().value(), errorCode.getMessage());
-        this.errorCode = errorCode;
-    }
-}
-

--- a/src/main/java/plango/room/application/dto/request/RoomCreateRequest.java
+++ b/src/main/java/plango/room/application/dto/request/RoomCreateRequest.java
@@ -9,18 +9,18 @@ import java.util.List;
 
 public record RoomCreateRequest(
 
-        @NotBlank
-        @Size(max = 50)
+        @NotBlank(message = "여행방 이름은 필수입니다.")
+        @Size(max = 50, message = "여행방 이름은 50자를 초과할 수 없습니다.")
         String roomName,
 
         String memo,
 
-        @NotNull
+        @NotNull(message = "여행 시작일은 필수입니다.")
         LocalDate startDate,
 
-        @NotNull
+        @NotNull(message = "여행 종료일은 필수입니다.")
         LocalDate endDate,
 
-        @NotEmpty
-        List<Long> memberIds
+        @NotEmpty(message = "여행 멤버는 최소 1명 이상이어야 합니다.")
+        List<@NotNull Long> memberIds
 ) {}

--- a/src/main/java/plango/room/application/dto/request/RoomCreateRequest.java
+++ b/src/main/java/plango/room/application/dto/request/RoomCreateRequest.java
@@ -1,0 +1,26 @@
+package plango.room.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+
+public record RoomCreateRequest(
+
+        @NotBlank
+        @Size(max = 50)
+        String roomName,
+
+        String memo,
+
+        @NotNull
+        LocalDate startDate,
+
+        @NotNull
+        LocalDate endDate,
+
+        @NotEmpty
+        List<Long> memberIds
+) {}

--- a/src/main/java/plango/room/application/dto/response/RoomCreateResponse.java
+++ b/src/main/java/plango/room/application/dto/response/RoomCreateResponse.java
@@ -1,0 +1,16 @@
+package plango.room.application.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record RoomCreateResponse(
+        Long roomId,
+        String roomName,
+        String memo,
+        LocalDate startDate,
+        LocalDate endDate,
+        Long ownerId,
+        List<Long> memberIds
+) {}

--- a/src/main/java/plango/room/application/mapper/RoomMapper.java
+++ b/src/main/java/plango/room/application/mapper/RoomMapper.java
@@ -1,0 +1,43 @@
+package plango.room.application.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import plango.member.domain.entity.Member;
+import plango.room.application.dto.request.RoomCreateRequest;
+import plango.room.application.dto.response.RoomCreateResponse;
+import plango.room.domain.entity.Room;
+import plango.room.domain.entity.RoomMember;
+
+@Component
+public class RoomMapper {
+
+    public Room toEntity(RoomCreateRequest request, Member owner) {
+        return new Room(
+                request.roomName(),
+                request.memo(),
+                request.startDate(),
+                request.endDate(),
+                owner
+        );
+    }
+
+    public RoomCreateResponse toCreateResponse(Room room) {
+
+        List<Long> memberIds = room.getMembers()
+                .stream()
+                .map(RoomMember::getMember)
+                .map(Member::getId)
+                .collect(Collectors.toList());
+
+        return RoomCreateResponse.builder()
+                .roomId(room.getId())
+                .roomName(room.getName())
+                .memo(room.getMemo())
+                .startDate(room.getStartDate())
+                .endDate(room.getEndDate())
+                .ownerId(room.getOwner().getId())
+                .memberIds(memberIds)
+                .build();
+    }
+}

--- a/src/main/java/plango/room/application/usecase/CreateRoomUseCase.java
+++ b/src/main/java/plango/room/application/usecase/CreateRoomUseCase.java
@@ -1,0 +1,41 @@
+package plango.room.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberGetService;
+import plango.room.application.dto.request.RoomCreateRequest;
+import plango.room.application.dto.response.RoomCreateResponse;
+import plango.room.application.mapper.RoomMapper;
+import plango.room.domain.entity.Room;
+import plango.room.domain.service.RoomMemberSaveService;
+import plango.room.domain.service.RoomSaveService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CreateRoomUseCase {
+
+    private final MemberGetService memberGetService;
+    private final RoomSaveService roomSaveService;
+    private final RoomMemberSaveService roomMemberSaveService;
+    private final RoomMapper roomMapper;
+
+    public RoomCreateResponse execute(Long ownerId, RoomCreateRequest request) {
+
+        Member owner = memberGetService.getById(ownerId);
+
+        Room room = roomMapper.toEntity(request, owner);
+        Room savedRoom = roomSaveService.save(room);
+
+        roomMemberSaveService.addOwner(savedRoom, owner);
+
+        request.memberIds().forEach(memberId -> {
+            Member member = memberGetService.getById(memberId);
+            roomMemberSaveService.addMember(savedRoom, member);
+        });
+
+        return roomMapper.toCreateResponse(savedRoom);
+    }
+}

--- a/src/main/java/plango/room/domain/entity/Room.java
+++ b/src/main/java/plango/room/domain/entity/Room.java
@@ -1,0 +1,76 @@
+package plango.room.domain.entity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plango.global.common.entity.BaseTimeEntity;
+import plango.member.domain.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Room extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String memo;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false)
+    private Member owner;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoomMember> members = new ArrayList<>();
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WishlistItem> wishlistItems = new ArrayList<>();
+
+    public Room(
+            String name,
+            String memo,
+            LocalDate startDate,
+            LocalDate endDate,
+            Member owner
+    ) {
+        this.name = name;
+        this.memo = memo;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.owner = owner;
+    }
+
+    public void addMember(RoomMember roomMember) {
+        this.members.add(roomMember);
+        roomMember.setRoom(this);
+    }
+
+    public void addWishlistItem(WishlistItem wishlistItem) {
+        this.wishlistItems.add(wishlistItem);
+        wishlistItem.setRoom(this);
+    }
+}

--- a/src/main/java/plango/room/domain/entity/RoomMember.java
+++ b/src/main/java/plango/room/domain/entity/RoomMember.java
@@ -1,0 +1,53 @@
+package plango.room.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.EnumType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plango.global.common.entity.BaseTimeEntity;
+import plango.member.domain.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoomMember extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private RoomRole role;
+
+    public RoomMember(
+            Room room,
+            Member member,
+            RoomRole role
+    ) {
+        this.room = room;
+        this.member = member;
+        this.role = role;
+    }
+
+    void setRoom(Room room) {
+        this.room = room;
+    }
+}

--- a/src/main/java/plango/room/domain/entity/RoomRole.java
+++ b/src/main/java/plango/room/domain/entity/RoomRole.java
@@ -1,0 +1,6 @@
+package plango.room.domain.entity;
+
+public enum RoomRole {
+    OWNER,
+    MEMBER
+}

--- a/src/main/java/plango/room/domain/entity/WishlistItem.java
+++ b/src/main/java/plango/room/domain/entity/WishlistItem.java
@@ -1,0 +1,63 @@
+package plango.room.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plango.global.common.entity.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WishlistItem extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @Column(nullable = false)
+    private String placeName;
+
+    private String address;
+
+    private String category;
+
+    private String memo;
+
+    private Integer dayIndex;
+
+    private Integer orderIndex;
+
+    public WishlistItem(
+            Room room,
+            String placeName,
+            String address,
+            String category,
+            String memo,
+            Integer dayIndex,
+            Integer orderIndex
+    ) {
+        this.room = room;
+        this.placeName = placeName;
+        this.address = address;
+        this.category = category;
+        this.memo = memo;
+        this.dayIndex = dayIndex;
+        this.orderIndex = orderIndex;
+    }
+
+    void setRoom(Room room) {
+        this.room = room;
+    }
+}

--- a/src/main/java/plango/room/domain/repository/RoomMemberRepository.java
+++ b/src/main/java/plango/room/domain/repository/RoomMemberRepository.java
@@ -1,0 +1,7 @@
+package plango.room.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import plango.room.domain.entity.RoomMember;
+
+public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
+}

--- a/src/main/java/plango/room/domain/repository/RoomRepository.java
+++ b/src/main/java/plango/room/domain/repository/RoomRepository.java
@@ -1,0 +1,7 @@
+package plango.room.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import plango.room.domain.entity.Room;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/src/main/java/plango/room/domain/repository/WishlistItemRepository.java
+++ b/src/main/java/plango/room/domain/repository/WishlistItemRepository.java
@@ -1,0 +1,7 @@
+package plango.room.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import plango.room.domain.entity.WishlistItem;
+
+public interface WishlistItemRepository extends JpaRepository<WishlistItem, Long> {
+}

--- a/src/main/java/plango/room/domain/service/RoomMemberSaveService.java
+++ b/src/main/java/plango/room/domain/service/RoomMemberSaveService.java
@@ -1,0 +1,28 @@
+package plango.room.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.member.domain.entity.Member;
+import plango.room.domain.entity.Room;
+import plango.room.domain.entity.RoomMember;
+import plango.room.domain.entity.RoomRole;
+import plango.room.domain.repository.RoomMemberRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RoomMemberSaveService {
+
+    private final RoomMemberRepository roomMemberRepository;
+
+    public RoomMember addOwner(Room room, Member owner) {
+        RoomMember roomMember = new RoomMember(room, owner, RoomRole.OWNER);
+        return roomMemberRepository.save(roomMember);
+    }
+
+    public RoomMember addMember(Room room, Member member) {
+        RoomMember roomMember = new RoomMember(room, member, RoomRole.MEMBER);
+        return roomMemberRepository.save(roomMember);
+    }
+}

--- a/src/main/java/plango/room/domain/service/RoomSaveService.java
+++ b/src/main/java/plango/room/domain/service/RoomSaveService.java
@@ -1,0 +1,19 @@
+package plango.room.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.room.domain.entity.Room;
+import plango.room.domain.repository.RoomRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RoomSaveService {
+
+    private final RoomRepository roomRepository;
+
+    public Room save(Room room) {
+        return roomRepository.save(room);
+    }
+}

--- a/src/main/java/plango/room/presentation/RoomController.java
+++ b/src/main/java/plango/room/presentation/RoomController.java
@@ -1,0 +1,35 @@
+package plango.room.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plango.global.common.response.CommonResponse;
+import plango.global.common.response.ResponseMessage;
+import plango.room.application.dto.request.RoomCreateRequest;
+import plango.room.application.dto.response.RoomCreateResponse;
+import plango.room.application.usecase.CreateRoomUseCase;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rooms")
+@Tag(name = "room-controller", description = "여행방 API")
+public class RoomController {
+
+    private final CreateRoomUseCase createRoomUseCase;
+
+    @PostMapping
+    @Operation(summary = "여행방 생성", description = "로그인한 사용자를 방장으로 하여 여행방을 생성합니다.")
+    public CommonResponse<RoomCreateResponse> createRoom(
+            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @Valid @RequestBody RoomCreateRequest request
+    ) {
+        RoomCreateResponse response = createRoomUseCase.execute(memberId, request);
+        return CommonResponse.success(ResponseMessage.SUCCESS, response);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,10 +4,11 @@ spring:
       on-profile: local
 
   datasource:
-    url: ${SPRING_DATASOURCE_URL:${DB_URL}}
-    username: ${SPRING_DATASOURCE_USERNAME:${DB_USER}}
-    password: ${SPRING_DATASOURCE_PASSWORD:${DB_PASSWORD}}
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
 
   jpa:
     show-sql: true
@@ -32,8 +33,8 @@ cloud:
     s3:
       bucket: ${S3_BUCKET:}
     credentials:
-      access-key: ${S3_ACCESS_KEY:}
-      secret-key: ${S3_SECRET_KEY:}
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
     region:
       static: ${S3_REGION:ap-southeast-2}
       auto: false
@@ -42,9 +43,9 @@ cloud:
 
 flyway:
   enabled: true
-  url: ${SPRING_DATASOURCE_URL:${DB_URL}}
-  user: ${SPRING_DATASOURCE_USERNAME:${DB_USER}}
-  password: ${SPRING_DATASOURCE_PASSWORD:${DB_PASSWORD}}
+  url: ${DB_URL}
+  user: ${DB_USER}
+  password: ${DB_PASSWORD}
   baseline-on-migrate: true
   baseline-version: 1
   locations: classpath:db/migration
@@ -56,3 +57,8 @@ security:
 preview:
   api:
     url: ${PREVIEW_API_URL:http://localhost:3000}
+oauth2:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+
+    redirect-uri: ${KAKAO_REDIRECT_URI}

--- a/src/main/resources/db/migration/V3__create_room_table.sql
+++ b/src/main/resources/db/migration/V3__create_room_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE room (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+
+    name VARCHAR(50) NOT NULL,
+    memo TEXT,
+
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+
+    owner_id BIGINT NOT NULL,
+
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NULL,
+
+     CONSTRAINT fk_room_owner
+        FOREIGN KEY (owner_id) REFERENCES member(id)
+        ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/V4__create_wishlist_item_table.sql
+++ b/src/main/resources/db/migration/V4__create_wishlist_item_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE wishlist_item (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+
+    room_id BIGINT NOT NULL,
+
+    place_name VARCHAR(255) NOT NULL,
+    address VARCHAR(255),
+    category VARCHAR(255),
+    memo TEXT,
+
+    day_index INT,
+    order_index INT,
+
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NULL,
+
+    CONSTRAINT fk_wishlist_room
+        FOREIGN KEY (room_id) REFERENCES room(id)
+            ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/V5__create_room_member_table.sql
+++ b/src/main/resources/db/migration/V5__create_room_member_table.sql
@@ -1,0 +1,19 @@
+CREATE TABLE room_member (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+
+    room_id BIGINT NOT NULL,
+    member_id BIGINT NOT NULL,
+
+    role VARCHAR(20) NOT NULL,
+
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NULL,
+
+    CONSTRAINT fk_room_member_room
+        FOREIGN KEY (room_id) REFERENCES room(id)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_room_member_member
+        FOREIGN KEY (member_id) REFERENCES member(id)
+        ON DELETE CASCADE
+);

--- a/src/main/resources/db/migration/V6__alter_room_member_role_enum.sql
+++ b/src/main/resources/db/migration/V6__alter_room_member_role_enum.sql
@@ -1,0 +1,2 @@
+ALTER TABLE room_member
+    MODIFY COLUMN role ENUM('OWNER', 'MEMBER') NOT NULL;


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #25 

## 🔎 작업 내용

•	POST /api/rooms 엔드포인트 추가
	•	요청 DTO에 roomName, memo, startDate, endDate, memberIds 필드 정의
	•	X-MEMBER-ID 헤더로 요청 유저를 방장(ownerId)으로 설정
	•	방 생성 시 Room 저장 후, 방장 + 초대 멤버를 RoomMember에 함께 저장되도록 로직 구현

<br>


## 📌 참고 사항

- 집중 리뷰 <!--(선택 사항)-->
    •	방 생성 시 Room + RoomMember를 한 번에 생성하는 트랜잭션 구조가 괜찮은지 확인 부탁드립니다.
	•	X-MEMBER-ID 헤더로 방장을 주입하는 방식이 팀 전체 인증/인가 전략과 맞는지 봐주시면 좋겠습니다.
	•	RoomResponse에 포함된 필드(특히 memberIds)가 프론트 요구사항에 충분한지/불필요한 필드는 없는지도 피드백 부탁드립니다.
<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
<img width="510" height="755" alt="스크린샷 2025-11-28 오전 2 26 57" src="https://github.com/user-attachments/assets/48080919-c380-40a0-8b63-266a9cb117c2" />

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수