### PR TITLE
feat/#14/유저-로그아웃

### DIFF
--- a/src/main/java/plango/auth/application/usecase/LogoutUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/LogoutUseCase.java
@@ -1,0 +1,17 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LogoutUseCase {
+
+    public void execute() {
+        // 현재는 서버에서 별도의 세션이나 토큰을 저장하지 않습니다.
+        // 추후 리프레시 토큰, 세션 등을 도입하면
+        // 이 메서드에서 무효화 로직을 추가합니다.
+    }
+}

--- a/src/main/java/plango/auth/domain/service/KakaoAuthService.java
+++ b/src/main/java/plango/auth/domain/service/KakaoAuthService.java
@@ -26,10 +26,10 @@ public class KakaoAuthService {
 
     private final RestTemplate restTemplate;
 
-    @Value("${oauth2.kakao.client-id}")
+    @Value("${security.oauth2.kakao.client-id}")
     private String clientId;
 
-    @Value("${oauth2.kakao.redirect-uri}")
+    @Value("${security.oauth2.kakao.redirect-uri}")
     private String redirectUri;
 
     public KakaoUserInfoResponse getUserInfoByAuthorizationCode(String authorizationCode) {

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -14,6 +14,7 @@ import plango.auth.application.dto.request.MemberLoginRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.usecase.KakaoLoginUseCase;
 import plango.auth.application.usecase.MemberLoginUseCase;
+import plango.auth.application.usecase.LogoutUseCase;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
@@ -25,6 +26,7 @@ public class AuthController {
 
     private final KakaoLoginUseCase kakaoLoginUseCase;
     private final MemberLoginUseCase memberLoginUseCase;
+    private final LogoutUseCase logoutUseCase;
 
     @Operation(summary = "일반 로그인", description = "아이디와 비밀번호로 로그인합니다.")
     @PostMapping("/login")
@@ -45,6 +47,15 @@ public class AuthController {
         KakaoLoginResponse response = kakaoLoginUseCase.execute(request);
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.SUCCESS, response)
+        );
+    }
+
+    @Operation(summary = "로그아웃", description = "로그인 정보를 삭제하고 로그아웃합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<CommonResponse<Void>> logout() {
+        logoutUseCase.execute();
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS, null)
         );
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #28 

## 🔎 작업 내용

- 로그아웃 기능 기본 구조 구현
  - LogoutUseCase 신규 추가
  - AuthController 에 POST /api/auth/logout 엔드포인트 추가
  - 응답 형식은 기존 컨벤션(CommonResponse, ResponseMessage.SUCCESS)을 준수
- Swagger UI 에서 로그아웃 API 노출되도록 설정 완료
- 기존 로그인 기능과 동일한 구조(Controller → UseCase) 유지하여 확장성 확보
- 서버 측에서 별도 세션/토큰 저장을 하지 않는 현재 구조에 맞게 
"프론트에서 로그인 상태 제거 → 화면 이동" 방식으로 사용 가능하도록 구현

<br>


## 📌 참고 사항

- 집중 리뷰 <!--(선택 사항)-->
    - 로그아웃 엔드포인트 네이밍 (/api/auth/logout) 이 컨벤션과 프로젝트 기획에 맞는지
    - 추후 리프레시 토큰/세션 도입 시 LogoutUseCase 내부 확장 방향 검토 필요
- 기타 안내 사항 <!--(선택 사항)-->
    - 로그아웃 요청은 Request Body 없이 POST 호출만 하면 동작하도록 구현됨
    - Swagger 상에서는 Try it out → Execute 로 200 응답을 확인 가능

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
<img width="1417" height="824" alt="image" src="https://github.com/user-attachments/assets/cebcec8b-4bdb-4aa9-ad4e-77299376f314" />

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수