### PR TITLE
Feat/#21/유저 닉네임 생성 및 중복 검증 기능 구현

### DIFF
--- a/src/main/java/plango/member/application/dto/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/plango/member/application/dto/request/MemberProfileUpdateRequest.java
@@ -1,6 +1,11 @@
 package plango.member.application.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 public record MemberProfileUpdateRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 50, message = "닉네임은 50자 이하여야 합니다.")
         String nickname,
         String profileImageUrl
 ) {

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -28,12 +28,11 @@ public class Member extends BaseTimeEntity {
     @Column(length = 200)
     private String password;
 
-    @Column(nullable = false, length = 50)
+    @Column(nullable = false, unique = true, length = 50)
     private String nickname;
 
     @Column(length = 255)
     private String profileImageUrl;
-
 
     public static Member createKakaoMember(
             String email,
@@ -51,5 +50,4 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
     }
-
 }

--- a/src/main/java/plango/member/domain/repository/MemberRepository.java
+++ b/src/main/java/plango/member/domain/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByLoginId(String loginId);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/plango/member/domain/service/MemberService.java
+++ b/src/main/java/plango/member/domain/service/MemberService.java
@@ -29,6 +29,10 @@ public class MemberService {
         return memberRepository.findByEmail(email);
     }
 
+    public Optional<Member> findByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname);
+    }
+
     @Transactional
     public Member save(Member member) {
         return memberRepository.save(member);
@@ -37,6 +41,11 @@ public class MemberService {
     @Transactional
     public void updateProfile(Long memberId, String nickname, String profileImageUrl) {
         Member member = getById(memberId);
+
+        if (nickname != null && !nickname.equals(member.getNickname())) {
+            validateNicknameUnique(nickname);
+        }
+
         member.updateProfile(nickname, profileImageUrl);
     }
 
@@ -49,6 +58,13 @@ public class MemberService {
         }
 
         return member;
+    }
+
+    private void validateNicknameUnique(String nickname) {
+        memberRepository.findByNickname(nickname)
+                .ifPresent(existingMember -> {
+                    throw new MemberException(MemberErrorCode.DUPLICATE_NICKNAME);
+                });
     }
 
     private boolean isPasswordMatch(Member member, String rawPassword) {

--- a/src/main/java/plango/member/exception/MemberErrorCode.java
+++ b/src/main/java/plango/member/exception/MemberErrorCode.java
@@ -11,6 +11,8 @@ public enum MemberErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "Member not found"),
     INVALID_MEMBER_STATUS(HttpStatus.BAD_REQUEST, "Invalid member status"),
 
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
+
     // 아이디 또는 비밀번호가 틀린 경우
     INVALID_MEMBER_CREDENTIAL(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 일치하지 않습니다.");
 

--- a/src/main/resources/db/migration/V12__add_unique_constraint_to_member_nickname.sql
+++ b/src/main/resources/db/migration/V12__add_unique_constraint_to_member_nickname.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member
+    ADD CONSTRAINT uk_member_nickname UNIQUE (nickname);


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #39 

## 🔎 작업 내용

- Member 엔티티에 `nickname` UNIQUE 제약 추가
- MemberProfileUpdateRequest에 닉네임 검증(@NotBlank, @Size) 추가
- MemberRepository에 `findByNickname` 메서드 추가
- MemberService에서 닉네임 중복 검증(`validateNicknameUnique`) 로직 구현
- 프로필 수정 API(`/api/members/{memberId}`)에서 닉네임 최초 생성 및 수정 기능 통합 처리
- Flyway 마이그레이션(V12) 수행하여 nickname unique constraint 반영

<br>

## 📌 참고 사항

- **집중 리뷰**
    - 닉네임 UNIQUE 제약 추가로 인해 기존 DB 데이터 중복이 제거됨
    - `updateProfile` 로직이 닉네임 최초 설정과 수정 기능 모두 담당하도록 의도적으로 설계함

- **기타 안내 사항**
    - 카카오 신규 유저의 최초 로그인 시 닉네임 설정 플로우에서도 해당 API를 그대로 사용 가능함
    - 이후 진행될 친구 기능(이슈2~4)의 기반이 되는 사전 단계 구현입니다.

- **주의해야 할 점**
    - 로컬 DB에 마이그레이션 적용 시, 기존 중복 닉네임이 있을 경우 Flyway에서 실패할 수 있음
    - 운영/공유 DB에 반영 시에는 반드시 중복 데이터 확인 필요

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
<img width="1278" height="815" alt="image" src="https://github.com/user-attachments/assets/7e3851c2-70ea-4913-ba62-f50143ca285f" />

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수