### PR TITLE
Feat/#22/닉네임 기반 친구 추가 기능 구현

### DIFF
--- a/src/main/java/plango/friend/application/dto/request/FriendRequestRequest.java
+++ b/src/main/java/plango/friend/application/dto/request/FriendRequestRequest.java
@@ -1,0 +1,9 @@
+package plango.friend.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FriendRequestRequest(
+        @NotBlank(message = "친구로 추가할 닉네임은 필수입니다.")
+        String targetNickname
+) {
+}

--- a/src/main/java/plango/friend/application/dto/response/FriendResponse.java
+++ b/src/main/java/plango/friend/application/dto/response/FriendResponse.java
@@ -1,0 +1,10 @@
+package plango.friend.application.dto.response;
+
+public record FriendResponse(
+        Long friendId,
+        Long requesterId,
+        Long receiverId,
+        String receiverNickname,
+        String status
+) {
+}

--- a/src/main/java/plango/friend/application/exception/FriendErrorCode.java
+++ b/src/main/java/plango/friend/application/exception/FriendErrorCode.java
@@ -1,0 +1,23 @@
+package plango.friend.application.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FriendErrorCode {
+
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 관계를 찾을 수 없습니다."),
+    CANNOT_REQUEST_SELF(HttpStatus.BAD_REQUEST, "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
+    FRIEND_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 친구 상태입니다."),
+    FRIEND_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 친구 요청이 존재합니다."),
+    FRIEND_TARGET_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 닉네임의 사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    public int getStatusCode() {
+        return status.value();
+    }
+}

--- a/src/main/java/plango/friend/application/exception/FriendException.java
+++ b/src/main/java/plango/friend/application/exception/FriendException.java
@@ -1,0 +1,15 @@
+package plango.friend.application.exception;
+
+import lombok.Getter;
+import plango.global.common.exception.BusinessException;
+
+@Getter
+public class FriendException extends BusinessException {
+
+    private final FriendErrorCode errorCode;
+
+    public FriendException(FriendErrorCode errorCode) {
+        super(errorCode.getStatusCode(), errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/plango/friend/application/mapper/FriendMapper.java
+++ b/src/main/java/plango/friend/application/mapper/FriendMapper.java
@@ -1,0 +1,19 @@
+package plango.friend.application.mapper;
+
+import org.springframework.stereotype.Component;
+import plango.friend.application.dto.response.FriendResponse;
+import plango.friend.domain.entity.Friend;
+
+@Component
+public class FriendMapper {
+
+    public FriendResponse toFriendResponse(Friend friend) {
+        return new FriendResponse(
+                friend.getId(),
+                friend.getRequester().getId(),
+                friend.getReceiver().getId(),
+                friend.getReceiver().getNickname(),
+                friend.getStatus().name()
+        );
+    }
+}

--- a/src/main/java/plango/friend/application/usecase/FriendRequestUseCase.java
+++ b/src/main/java/plango/friend/application/usecase/FriendRequestUseCase.java
@@ -1,0 +1,38 @@
+package plango.friend.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.friend.application.dto.request.FriendRequestRequest;
+import plango.friend.application.dto.response.FriendResponse;
+import plango.friend.application.exception.FriendErrorCode;
+import plango.friend.application.exception.FriendException;
+import plango.friend.application.mapper.FriendMapper;
+import plango.friend.domain.entity.Friend;
+import plango.friend.domain.service.FriendSaveService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.repository.MemberRepository;
+import plango.member.domain.service.MemberGetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FriendRequestUseCase {
+
+    private final MemberGetService memberGetService;
+    private final MemberRepository memberRepository;
+    private final FriendSaveService friendSaveService;
+    private final FriendMapper friendMapper;
+
+    @Transactional
+    public FriendResponse execute(Long requesterId, FriendRequestRequest request) {
+        Member requester = memberGetService.getById(requesterId);
+
+        Member receiver = memberRepository.findByNickname(request.targetNickname())
+                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_TARGET_NOT_FOUND));
+
+        Friend friend = friendSaveService.requestFriend(requester, receiver);
+
+        return friendMapper.toFriendResponse(friend);
+    }
+}

--- a/src/main/java/plango/friend/domain/entity/Friend.java
+++ b/src/main/java/plango/friend/domain/entity/Friend.java
@@ -1,0 +1,55 @@
+package plango.friend.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plango.global.common.entity.BaseTimeEntity;
+import plango.member.domain.entity.Member;
+
+@Getter
+@Entity
+@Table(name = "friend")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Friend extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester_id", nullable = false)
+    private Member requester;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private Member receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private FriendStatus status;
+
+    private Friend(Member requester, Member receiver, FriendStatus status) {
+        this.requester = requester;
+        this.receiver = receiver;
+        this.status = status;
+    }
+
+    public static Friend request(Member requester, Member receiver) {
+        return new Friend(requester, receiver, FriendStatus.REQUESTED);
+    }
+
+    public void accept() {
+        this.status = FriendStatus.ACCEPTED;
+    }
+}

--- a/src/main/java/plango/friend/domain/entity/FriendStatus.java
+++ b/src/main/java/plango/friend/domain/entity/FriendStatus.java
@@ -1,0 +1,7 @@
+package plango.friend.domain.entity;
+
+public enum FriendStatus {
+
+    REQUESTED,
+    ACCEPTED
+}

--- a/src/main/java/plango/friend/domain/repository/FriendRepository.java
+++ b/src/main/java/plango/friend/domain/repository/FriendRepository.java
@@ -1,0 +1,20 @@
+package plango.friend.domain.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import plango.friend.domain.entity.Friend;
+import plango.member.domain.entity.Member;
+
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+    boolean existsByRequesterAndReceiver(Member requester, Member receiver);
+
+    boolean existsByRequesterAndReceiverOrRequesterAndReceiver(
+            Member requester,
+            Member receiver,
+            Member reversedRequester,
+            Member reversedReceiver
+    );
+
+    Optional<Friend> findByRequesterAndReceiver(Member requester, Member receiver);
+}

--- a/src/main/java/plango/friend/domain/service/FriendSaveService.java
+++ b/src/main/java/plango/friend/domain/service/FriendSaveService.java
@@ -1,0 +1,47 @@
+package plango.friend.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.friend.application.exception.FriendErrorCode;
+import plango.friend.application.exception.FriendException;
+import plango.friend.domain.entity.Friend;
+import plango.friend.domain.repository.FriendRepository;
+import plango.member.domain.entity.Member;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FriendSaveService {
+
+    private final FriendRepository friendRepository;
+
+    @Transactional
+    public Friend requestFriend(Member requester, Member receiver) {
+        validateNotSelf(requester, receiver);
+        validateFriendRelation(requester, receiver);
+
+        Friend friend = Friend.request(requester, receiver);
+        return friendRepository.save(friend);
+    }
+
+    private void validateNotSelf(Member requester, Member receiver) {
+        if (requester.getId().equals(receiver.getId())) {
+            throw new FriendException(FriendErrorCode.CANNOT_REQUEST_SELF);
+        }
+    }
+
+    private void validateFriendRelation(Member requester, Member receiver) {
+        boolean exists =
+                friendRepository.existsByRequesterAndReceiverOrRequesterAndReceiver(
+                        requester,
+                        receiver,
+                        receiver,
+                        requester
+                );
+
+        if (exists) {
+            throw new FriendException(FriendErrorCode.FRIEND_REQUEST_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/plango/friend/presentation/FriendController.java
+++ b/src/main/java/plango/friend/presentation/FriendController.java
@@ -1,0 +1,35 @@
+package plango.friend.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plango.friend.application.dto.request.FriendRequestRequest;
+import plango.friend.application.dto.response.FriendResponse;
+import plango.friend.application.usecase.FriendRequestUseCase;
+import plango.global.common.response.CommonResponse;
+import plango.global.common.response.ResponseMessage;
+
+@Tag(name = "Friend API", description = "친구 추가 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/friends")
+public class FriendController {
+
+    private final FriendRequestUseCase friendRequestUseCase;
+
+    @Operation(summary = "닉네임으로 친구 요청", description = "앱 내 닉네임으로 친구 요청을 생성합니다.")
+    @PostMapping
+    public CommonResponse<FriendResponse> requestFriend(
+            @RequestHeader("X-Member-Id") Long memberId,
+            @RequestBody @Valid FriendRequestRequest request
+    ) {
+        FriendResponse response = friendRequestUseCase.execute(memberId, request);
+        return CommonResponse.success(ResponseMessage.FRIEND_REQUEST_CREATE_SUCCESS, response);
+    }
+}

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -18,13 +18,17 @@ public enum ResponseMessage {
     NICKNAME_UPDATE_SUCCESS(0, "닉네임 수정 성공"),
     NICKNAME_CREATE_SUCCESS(0, "닉네임 생성 성공"),
 
-    // ===== 친구 요청 =====
+    // ===== 룸 일정(스케줄) =====
+    ROOM_SCHEDULE_CREATE_SUCCESS(0, "여행 일정 생성 성공"),
+    ROOM_SCHEDULE_GET_SUCCESS(0, "여행 일정 조회 성공"),
+    ROOM_SCHEDULE_UPDATE_SUCCESS(0, "여행 일정 수정 성공"),
+    ROOM_SCHEDULE_DELETE_SUCCESS(0, "여행 일정 삭제 성공"),
+
+    // ===== 친구 요청 / 관리 =====
     FRIEND_REQUEST_CREATE_SUCCESS(0, "친구 요청 생성 성공"),
     FRIEND_REQUEST_ALREADY_EXISTS(0, "이미 친구 요청이 존재합니다."),
     FRIEND_REQUEST_INVALID_SELF(0, "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
     FRIEND_TARGET_NOT_FOUND(0, "해당 닉네임의 사용자를 찾을 수 없습니다."),
-
-    // ===== 친구 응답 =====
     FRIEND_ACCEPT_SUCCESS(0, "친구 요청 수락 성공"),
     FRIEND_REJECT_SUCCESS(0, "친구 요청 거절 성공"),
     FRIEND_DELETE_SUCCESS(0, "친구 삭제 성공");

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -14,15 +14,20 @@ public enum ResponseMessage {
     MEMBER_PROFILE_GET_SUCCESS(0, "프로필 조회 성공"),
     MEMBER_PROFILE_UPDATE_SUCCESS(0, "프로필 수정 성공"),
 
+    // ===== 여행방 장소 (RoomPlace) =====
+    ROOM_PLACE_LIST_SUCCESS(0, "위시리스트 장소 조회 성공"),
+    ROOM_PLACE_CREATE_SUCCESS(0, "위시리스트 장소 생성 성공"),
+    ROOM_PLACE_DELETE_SUCCESS(0, "위시리스트 장소 삭제 성공"),
+
+    // ===== 여행방 일정 (RoomSchedule) =====
+    ROOM_SCHEDULE_CREATE_SUCCESS(0, "일정 생성 성공"),
+    ROOM_SCHEDULE_GET_SUCCESS(0, "일정 조회 성공"),
+    ROOM_SCHEDULE_UPDATE_SUCCESS(0, "일정 수정 성공"),
+    ROOM_SCHEDULE_DELETE_SUCCESS(0, "일정 삭제 성공"),
+
     // ===== 닉네임 =====
     NICKNAME_UPDATE_SUCCESS(0, "닉네임 수정 성공"),
     NICKNAME_CREATE_SUCCESS(0, "닉네임 생성 성공"),
-
-    // ===== 룸 일정(스케줄) =====
-    ROOM_SCHEDULE_CREATE_SUCCESS(0, "여행 일정 생성 성공"),
-    ROOM_SCHEDULE_GET_SUCCESS(0, "여행 일정 조회 성공"),
-    ROOM_SCHEDULE_UPDATE_SUCCESS(0, "여행 일정 수정 성공"),
-    ROOM_SCHEDULE_DELETE_SUCCESS(0, "여행 일정 삭제 성공"),
 
     // ===== 친구 요청 / 관리 =====
     FRIEND_REQUEST_CREATE_SUCCESS(0, "친구 요청 생성 성공"),

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -12,7 +12,20 @@ public enum ResponseMessage {
 
     // ===== 프로필 =====
     MEMBER_PROFILE_GET_SUCCESS(0, "프로필 조회 성공"),
-    MEMBER_PROFILE_UPDATE_SUCCESS(0, "프로필 수정 성공");
+    MEMBER_PROFILE_UPDATE_SUCCESS(0, "프로필 수정 성공"),
+
+    // ===== 닉네임 =====
+    NICKNAME_UPDATE_SUCCESS(0, "닉네임 수정 성공"),
+    NICKNAME_CREATE_SUCCESS(0, "닉네임 생성 성공"),
+
+    // ===== 친구 기능 =====
+    FRIEND_REQUEST_CREATE_SUCCESS(0, "친구 요청 생성 성공"),
+    FRIEND_REQUEST_ALREADY_EXISTS(0, "이미 친구 요청이 존재합니다."),
+    FRIEND_REQUEST_INVALID_SELF(0, "자기 자신에게는 친구 요청을 보낼 수 없습니다."),
+    FRIEND_TARGET_NOT_FOUND(0, "해당 닉네임의 사용자를 찾을 수 없습니다."),
+    FRIEND_ACCEPT_SUCCESS(0, "친구 요청 수락 성공"),
+    FRIEND_REJECT_SUCCESS(0, "친구 요청 거절 성공"),
+    FRIEND_DELETE_SUCCESS(0, "친구 삭제 성공");
 
     private final int code;
     private final String message;

--- a/src/main/resources/db/migration/V13__create_friend_table.sql
+++ b/src/main/resources/db/migration/V13__create_friend_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE friend (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    requester_id BIGINT NOT NULL,
+    receiver_id BIGINT NOT NULL,
+    status ENUM('requested', 'accepted') NOT NULL,
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_friend_requester
+        FOREIGN KEY (requester_id) REFERENCES member (id),
+    CONSTRAINT fk_friend_receiver
+        FOREIGN KEY (receiver_id) REFERENCES member (id),
+    CONSTRAINT uk_friend_requester_receiver
+        UNIQUE (requester_id, receiver_id)
+);


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #42 

🔎 작업 내용

닉네임 기반 친구 요청 기능 구현

Friend 도메인(Controller / UseCase / Service / Repository / Domain) 전체 개발

friend 테이블 생성 및 status(enum) 적용

자기 자신에게 친구 요청 시 예외 처리 (CANNOT_REQUEST_SELF)

이미 요청 또는 친구 상태인 경우 예외 처리 (FRIEND_REQUEST_ALREADY_EXISTS)

친구 요청 성공 시 FRIEND_REQUEST_CREATE_SUCCESS 응답 메시지 적용

회원 인증 헤더(X-Member-Id) 기반 요청자 식별

<br>
📌 참고 사항

Swagger에서 실제 테스트 완료:

친구 요청 성공 ✔️

자기 자신에게 요청 시 예외 발생 ✔️

중복 요청 시 예외 발생 ✔️

friend 테이블과 enum 매핑 정상 동작 확인

추가 필요 작업: 친구 수락/거절/취소 기능은 다음 이슈에서 진행 예정

<br>

## 📷 이미지 첨부
- 친구 추가 요청 성공
  <br>
  
<img width="1275" height="751" alt="성공" src="https://github.com/user-attachments/assets/24bdbc3f-d6b2-488b-a1b5-b41ce29f2ceb" />


<br/>

- 자기 자신 친구 추가(친구 추가 요청 실패)
  <br>
  
<img width="1289" height="773" alt="자기자신" src="https://github.com/user-attachments/assets/59ba5837-23d9-40d2-9e11-fb210ce2032c" />


<br/>

- 이미 친구인 친구 추가(친구 추가 요청 실패)
  <br>
  
<img width="1277" height="829" alt="이미" src="https://github.com/user-attachments/assets/048a9bb2-040f-4326-b16c-aefc5ab0f51d" />


<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수