### PR TITLE
feat/#28/일반 유저 회원가입

### DIFF
--- a/src/main/java/plango/auth/application/dto/request/MemberSignUpRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/MemberSignUpRequest.java
@@ -1,0 +1,37 @@
+package plango.auth.application.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record MemberSignUpRequest(
+
+        @NotBlank(message = "이름은 필수입니다.")
+        @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하여야 합니다.")
+        String name,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+        String nickname,
+
+        @NotBlank(message = "아이디는 필수입니다.")
+        @Pattern(
+                regexp = "^[a-z0-9]{4,16}$",
+                message = "아이디는 영문 소문자와 숫자 조합 4~16자여야 합니다."
+        )
+        String loginId,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^[A-Za-z0-9]{6,20}$",
+                message = "비밀번호는 영문 대소문자와 숫자 조합 6~20자여야 합니다."
+        )
+        String password,
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        @Size(max = 100, message = "이메일은 100자 이하여야 합니다.")
+        String email
+) {
+}

--- a/src/main/java/plango/auth/application/dto/response/DuplicateCheckResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/DuplicateCheckResponse.java
@@ -1,0 +1,8 @@
+package plango.auth.application.dto.response;
+
+public record DuplicateCheckResponse(
+        boolean available,
+        String field,
+        String value
+) {
+}

--- a/src/main/java/plango/auth/application/dto/response/MemberSignUpResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/MemberSignUpResponse.java
@@ -1,0 +1,10 @@
+package plango.auth.application.dto.response;
+
+public record MemberSignUpResponse(
+        Long memberId,
+        String name,
+        String nickname,
+        String loginId,
+        String email
+) {
+}

--- a/src/main/java/plango/auth/application/usecase/EmailDuplicateCheckUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/EmailDuplicateCheckUseCase.java
@@ -1,0 +1,21 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.response.DuplicateCheckResponse;
+import plango.member.domain.service.MemberService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailDuplicateCheckUseCase {
+
+    private final MemberService memberService;
+
+    public DuplicateCheckResponse execute(String email) {
+        boolean exists = memberService.existsByEmail(email);
+        boolean available = !exists;
+        return new DuplicateCheckResponse(available, "email", email);
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/LoginIdDuplicateCheckUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/LoginIdDuplicateCheckUseCase.java
@@ -1,0 +1,21 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.response.DuplicateCheckResponse;
+import plango.member.domain.service.MemberService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LoginIdDuplicateCheckUseCase {
+
+    private final MemberService memberService;
+
+    public DuplicateCheckResponse execute(String loginId) {
+        boolean exists = memberService.existsByLoginId(loginId);
+        boolean available = !exists;
+        return new DuplicateCheckResponse(available, "loginId", loginId);
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/MemberSignUpUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/MemberSignUpUseCase.java
@@ -1,0 +1,40 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.request.MemberSignUpRequest;
+import plango.auth.application.dto.response.MemberSignUpResponse;
+import plango.member.application.mapper.MemberMapper;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberService;
+import plango.member.exception.MemberErrorCode;
+import plango.member.exception.MemberException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MemberSignUpUseCase {
+
+    private final MemberService memberService;
+    private final MemberMapper memberMapper;
+
+    public MemberSignUpResponse execute(MemberSignUpRequest request) {
+        if (memberService.existsByLoginId(request.loginId())) {
+            throw new MemberException(MemberErrorCode.DUPLICATE_LOGIN_ID);
+        }
+
+        if (memberService.existsByEmail(request.email())) {
+            throw new MemberException(MemberErrorCode.DUPLICATE_EMAIL);
+        }
+
+        if (memberService.existsByNickname(request.nickname())) {
+            throw new MemberException(MemberErrorCode.DUPLICATE_NICKNAME);
+        }
+
+        Member member = memberMapper.toEntity(request);
+        Member saved = memberService.save(member);
+
+        return memberMapper.toSignUpResponse(saved);
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/NicknameDuplicateCheckUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/NicknameDuplicateCheckUseCase.java
@@ -1,0 +1,21 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.response.DuplicateCheckResponse;
+import plango.member.domain.service.MemberService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NicknameDuplicateCheckUseCase {
+
+    private final MemberService memberService;
+
+    public DuplicateCheckResponse execute(String nickname) {
+        boolean exists = memberService.existsByNickname(nickname);
+        boolean available = !exists;
+        return new DuplicateCheckResponse(available, "nickname", nickname);
+    }
+}

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -15,11 +15,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import plango.auth.application.dto.request.KakaoLoginRequest;
+import plango.auth.application.dto.request.MemberLoginRequest;
 import plango.auth.application.dto.request.MemberSignUpRequest;
 import plango.auth.application.dto.response.DuplicateCheckResponse;
+import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.dto.response.MemberSignUpResponse;
 import plango.auth.application.usecase.EmailDuplicateCheckUseCase;
+import plango.auth.application.usecase.KakaoLoginUseCase;
 import plango.auth.application.usecase.LoginIdDuplicateCheckUseCase;
+import plango.auth.application.usecase.LogoutUseCase;
+import plango.auth.application.usecase.MemberLoginUseCase;
 import plango.auth.application.usecase.MemberSignUpUseCase;
 import plango.auth.application.usecase.NicknameDuplicateCheckUseCase;
 import plango.global.common.response.CommonResponse;
@@ -35,6 +41,9 @@ public class AuthController {
     private final NicknameDuplicateCheckUseCase nicknameDuplicateCheckUseCase;
     private final LoginIdDuplicateCheckUseCase loginIdDuplicateCheckUseCase;
     private final EmailDuplicateCheckUseCase emailDuplicateCheckUseCase;
+    private final MemberLoginUseCase memberLoginUseCase;
+    private final KakaoLoginUseCase kakaoLoginUseCase;
+    private final LogoutUseCase logoutUseCase;
 
     @Operation(summary = "일반 회원가입", description = "이름, 닉네임, 아이디, 비밀번호, 이메일로 회원가입합니다.")
     @PostMapping("/signup")
@@ -46,6 +55,41 @@ public class AuthController {
         MemberSignUpResponse response = memberSignUpUseCase.execute(request);
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.MEMBER_SIGN_UP_SUCCESS, response)
+        );
+    }
+
+    @Operation(summary = "일반 로그인", description = "아이디와 비밀번호로 로그인합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<CommonResponse<KakaoLoginResponse>> login(
+            @Valid
+            @RequestBody
+            MemberLoginRequest request
+    ) {
+        KakaoLoginResponse response = memberLoginUseCase.execute(request);
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS, response)
+        );
+    }
+
+    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 사용해 로그인합니다.")
+    @PostMapping("/login/kakao")
+    public ResponseEntity<CommonResponse<KakaoLoginResponse>> kakaoLogin(
+            @Valid
+            @RequestBody
+            KakaoLoginRequest request
+    ) {
+        KakaoLoginResponse response = kakaoLoginUseCase.execute(request);
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS, response)
+        );
+    }
+
+    @Operation(summary = "로그아웃", description = "현재 로그인된 사용자를 로그아웃합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<CommonResponse<Void>> logout() {
+        logoutUseCase.execute();
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS)
         );
     }
 

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -3,18 +3,25 @@ package plango.auth.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import plango.auth.application.dto.request.KakaoLoginRequest;
-import plango.auth.application.dto.request.MemberLoginRequest;
-import plango.auth.application.dto.response.KakaoLoginResponse;
-import plango.auth.application.usecase.KakaoLoginUseCase;
-import plango.auth.application.usecase.LogoutUseCase;
-import plango.auth.application.usecase.MemberLoginUseCase;
+import plango.auth.application.dto.request.MemberSignUpRequest;
+import plango.auth.application.dto.response.DuplicateCheckResponse;
+import plango.auth.application.dto.response.MemberSignUpResponse;
+import plango.auth.application.usecase.EmailDuplicateCheckUseCase;
+import plango.auth.application.usecase.LoginIdDuplicateCheckUseCase;
+import plango.auth.application.usecase.MemberSignUpUseCase;
+import plango.auth.application.usecase.NicknameDuplicateCheckUseCase;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
@@ -24,45 +31,66 @@ import plango.global.common.response.ResponseMessage;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final KakaoLoginUseCase kakaoLoginUseCase;
-    private final MemberLoginUseCase memberLoginUseCase;
-    private final LogoutUseCase logoutUseCase;
+    private final MemberSignUpUseCase memberSignUpUseCase;
+    private final NicknameDuplicateCheckUseCase nicknameDuplicateCheckUseCase;
+    private final LoginIdDuplicateCheckUseCase loginIdDuplicateCheckUseCase;
+    private final EmailDuplicateCheckUseCase emailDuplicateCheckUseCase;
 
-    @Operation(summary = "일반 로그인", description = "로그인 ID와 비밀번호로 로그인합니다.")
-    @PostMapping("/login")
-    public ResponseEntity<CommonResponse<KakaoLoginResponse>> login(
+    @Operation(summary = "일반 회원가입", description = "이름, 닉네임, 아이디, 비밀번호, 이메일로 회원가입합니다.")
+    @PostMapping("/signup")
+    public ResponseEntity<CommonResponse<MemberSignUpResponse>> signUp(
             @Valid
             @RequestBody
-            MemberLoginRequest request
+            MemberSignUpRequest request
     ) {
-        KakaoLoginResponse response = memberLoginUseCase.execute(request);
-
+        MemberSignUpResponse response = memberSignUpUseCase.execute(request);
         return ResponseEntity.ok(
-                CommonResponse.success(ResponseMessage.SUCCESS, response)
+                CommonResponse.success(ResponseMessage.MEMBER_SIGN_UP_SUCCESS, response)
         );
     }
 
-    @Operation(summary = "카카오 로그인", description = "카카오 인가 코드를 사용하여 간편 로그인을 수행합니다.")
-    @PostMapping("/kakao/login")
-    public ResponseEntity<CommonResponse<KakaoLoginResponse>> kakaoLogin(
-            @Valid
-            @RequestBody
-            KakaoLoginRequest request
+    @Operation(summary = "닉네임 중복 확인", description = "닉네임이 사용 가능한지 확인합니다.")
+    @GetMapping("/check/nickname")
+    public ResponseEntity<CommonResponse<DuplicateCheckResponse>> checkNickname(
+            @RequestParam
+            @NotBlank(message = "닉네임은 필수입니다.")
+            @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하여야 합니다.")
+            String nickname
     ) {
-        KakaoLoginResponse response = kakaoLoginUseCase.execute(request);
-
+        DuplicateCheckResponse response = nicknameDuplicateCheckUseCase.execute(nickname);
         return ResponseEntity.ok(
-                CommonResponse.success(ResponseMessage.SUCCESS, response)
+                CommonResponse.success(ResponseMessage.MEMBER_NICKNAME_CHECK_SUCCESS, response)
         );
     }
 
-    @Operation(summary = "로그아웃", description = "로그인 정보를 삭제하고 로그아웃합니다.")
-    @PostMapping("/logout")
-    public ResponseEntity<CommonResponse<Void>> logout() {
-        logoutUseCase.execute();
-
+    @Operation(summary = "아이디 중복 확인", description = "아이디가 사용 가능한지 확인합니다.")
+    @GetMapping("/check/login-id")
+    public ResponseEntity<CommonResponse<DuplicateCheckResponse>> checkLoginId(
+            @RequestParam
+            @NotBlank(message = "아이디는 필수입니다.")
+            @Pattern(
+                    regexp = "^[a-z0-9]{4,16}$",
+                    message = "아이디는 영문 소문자와 숫자 조합 4~16자여야 합니다."
+            )
+            String loginId
+    ) {
+        DuplicateCheckResponse response = loginIdDuplicateCheckUseCase.execute(loginId);
         return ResponseEntity.ok(
-                CommonResponse.success(ResponseMessage.SUCCESS, null)
+                CommonResponse.success(ResponseMessage.MEMBER_LOGIN_ID_CHECK_SUCCESS, response)
+        );
+    }
+
+    @Operation(summary = "이메일 중복 확인", description = "이메일이 사용 가능한지 확인합니다.")
+    @GetMapping("/check/email")
+    public ResponseEntity<CommonResponse<DuplicateCheckResponse>> checkEmail(
+            @RequestParam
+            @NotBlank(message = "이메일은 필수입니다.")
+            @Email(message = "유효한 이메일 형식이 아닙니다.")
+            String email
+    ) {
+        DuplicateCheckResponse response = emailDuplicateCheckUseCase.execute(email);
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.MEMBER_EMAIL_CHECK_SUCCESS, response)
         );
     }
 }

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -10,6 +10,12 @@ public enum ResponseMessage {
     // ===== 공통 =====
     SUCCESS(0, "성공"),
 
+    MEMBER_SIGN_UP_SUCCESS(0, "회원가입 성공"),
+
+    MEMBER_NICKNAME_CHECK_SUCCESS(0, "닉네임 중복 확인 성공"),
+    MEMBER_LOGIN_ID_CHECK_SUCCESS(0, "아이디 중복 확인 성공"),
+    MEMBER_EMAIL_CHECK_SUCCESS(0, "이메일 중복 확인 성공"),
+
     // ===== 프로필 =====
     MEMBER_PROFILE_GET_SUCCESS(0, "프로필 조회 성공"),
     MEMBER_PROFILE_UPDATE_SUCCESS(0, "프로필 수정 성공"),

--- a/src/main/java/plango/member/application/mapper/MemberMapper.java
+++ b/src/main/java/plango/member/application/mapper/MemberMapper.java
@@ -1,6 +1,8 @@
 package plango.member.application.mapper;
 
 import org.springframework.stereotype.Component;
+import plango.auth.application.dto.request.MemberSignUpRequest;
+import plango.auth.application.dto.response.MemberSignUpResponse;
 import plango.member.application.dto.response.MemberProfileResponse;
 import plango.member.domain.entity.Member;
 
@@ -14,6 +16,26 @@ public class MemberMapper {
                 member.getEmail(),
                 member.getLoginId(),
                 member.getProfileImageUrl()
+        );
+    }
+
+    public Member toEntity(MemberSignUpRequest request) {
+        return Member.createLocalMember(
+                request.name(),
+                request.loginId(),
+                request.email(),
+                request.password(),
+                request.nickname()
+        );
+    }
+
+    public MemberSignUpResponse toSignUpResponse(Member member) {
+        return new MemberSignUpResponse(
+                member.getId(),
+                member.getName(),
+                member.getNickname(),
+                member.getLoginId(),
+                member.getEmail()
         );
     }
 }

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -2,6 +2,8 @@ package plango.member.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -37,6 +39,10 @@ public class Member extends BaseTimeEntity {
     @Column(length = 255)
     private String profileImageUrl;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_type", nullable = false, length = 20)
+    private LoginType loginType;
+
     public static Member createKakaoMember(
             String email,
             String nickname,
@@ -47,6 +53,7 @@ public class Member extends BaseTimeEntity {
         member.name = nickname;
         member.nickname = nickname;
         member.profileImageUrl = profileImageUrl;
+        member.loginType = LoginType.KAKAO;
         return member;
     }
 
@@ -63,6 +70,7 @@ public class Member extends BaseTimeEntity {
         member.email = email;
         member.password = password;
         member.nickname = nickname;
+        member.loginType = LoginType.NORMAL;
         return member;
     }
 

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -5,13 +5,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.EnumType;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import plango.global.common.entity.BaseTimeEntity;
-import plango.member.domain.entity.LoginType;
 
 @Getter
 @Entity
@@ -31,15 +28,14 @@ public class Member extends BaseTimeEntity {
     @Column(length = 200)
     private String password;
 
+    @Column(nullable = false, length = 50)
+    private String name;
+
     @Column(nullable = false, unique = true, length = 50)
     private String nickname;
 
     @Column(length = 255)
     private String profileImageUrl;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
-    private LoginType loginType;
 
     public static Member createKakaoMember(
             String email,
@@ -50,7 +46,22 @@ public class Member extends BaseTimeEntity {
         member.email = email;
         member.nickname = nickname;
         member.profileImageUrl = profileImageUrl;
-        member.loginType = LoginType.KAKAO;
+        return member;
+    }
+
+    public static Member createLocalMember(
+            String name,
+            String loginId,
+            String email,
+            String password,
+            String nickname
+    ) {
+        Member member = new Member();
+        member.name = name;
+        member.loginId = loginId;
+        member.email = email;
+        member.password = password;
+        member.nickname = nickname;
         return member;
     }
 
@@ -59,26 +70,7 @@ public class Member extends BaseTimeEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public static Member createNormalMember(
-            String loginId,
-            String email,
-            String encodedPassword,
-            String nickname
-    ) {
-        Member member = new Member();
-        member.loginId = loginId;
-        member.email = email;
-        member.password = encodedPassword;
-        member.nickname = nickname;
-        member.loginType = LoginType.NORMAL;
-        return member;
-    }
-
-    public boolean isSocialMember() {
-        return this.loginType == LoginType.KAKAO;
-    }
-
-    public void updatePassword(String encodedPassword) {
-        this.password = encodedPassword;
+    public void changePassword(String newPassword) {
+        this.password = newPassword;
     }
 }

--- a/src/main/java/plango/member/domain/entity/Member.java
+++ b/src/main/java/plango/member/domain/entity/Member.java
@@ -44,6 +44,7 @@ public class Member extends BaseTimeEntity {
     ) {
         Member member = new Member();
         member.email = email;
+        member.name = nickname;
         member.nickname = nickname;
         member.profileImageUrl = profileImageUrl;
         return member;

--- a/src/main/java/plango/member/domain/repository/MemberRepository.java
+++ b/src/main/java/plango/member/domain/repository/MemberRepository.java
@@ -11,4 +11,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickname);
+
+    boolean existsByLoginId(String loginId);
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/plango/member/domain/service/MemberService.java
+++ b/src/main/java/plango/member/domain/service/MemberService.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import plango.member.domain.entity.Member;
 import plango.member.domain.repository.MemberRepository;
 import plango.member.exception.MemberErrorCode;
@@ -16,10 +15,10 @@ import plango.member.exception.MemberException;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
 
     public Member getById(Long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository
+                .findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 
@@ -35,78 +34,63 @@ public class MemberService {
         return memberRepository.findByNickname(nickname);
     }
 
+    public boolean existsByLoginId(String loginId) {
+        return memberRepository.existsByLoginId(loginId);
+    }
+
+    public boolean existsByEmail(String email) {
+        return memberRepository.existsByEmail(email);
+    }
+
+    public boolean existsByNickname(String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
+
     @Transactional
     public Member save(Member member) {
         return memberRepository.save(member);
     }
 
     @Transactional
-    public void updateProfile(Long memberId, String nickname, String profileImageUrl) {
-        Member member = getById(memberId);
-
-        if (nickname != null && !nickname.equals(member.getNickname())) {
-            validateNicknameUnique(nickname);
-        }
-
-        member.updateProfile(nickname, profileImageUrl);
-    }
-
-    @Transactional
-    public void changePassword(Long memberId,
-                               String currentPassword,
-                               String newPassword,
-                               String newPasswordConfirm) {
-
-        Member member = getById(memberId);
-
-        // 소셜(카카오) 회원은 비밀번호 변경 불가
-        if (member.isSocialMember()) {
-            throw new MemberException(MemberErrorCode.PASSWORD_CHANGE_NOT_ALLOWED_FOR_SOCIAL_MEMBER);
-        }
-
-        // 현재 비밀번호 검증
-        if (!isPasswordMatch(member, currentPassword)) {
-            throw new MemberException(MemberErrorCode.INVALID_CURRENT_PASSWORD);
-        }
-
-        // 새 비밀번호 & 확인 일치 여부 검증
-        if (!newPassword.equals(newPasswordConfirm)) {
-            throw new MemberException(MemberErrorCode.NEW_PASSWORD_CONFIRM_NOT_MATCH);
-        }
-
-        // 이전 비밀번호와 동일한지 검증
-        if (isPasswordMatch(member, newPassword)) {
-            throw new MemberException(MemberErrorCode.NEW_PASSWORD_SAME_AS_OLD);
-        }
-
-        // 비밀번호 변경
-        String encodedNewPassword = passwordEncoder.encode(newPassword);
-        member.updatePassword(encodedNewPassword);
-    }
-
-    public Member loginByLoginId(String loginId, String rawPassword) {
-        Member member = memberRepository.findByLoginId(loginId)
+    public Member loginByLoginId(String loginId, String password) {
+        Member member = memberRepository
+                .findByLoginId(loginId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.INVALID_MEMBER_CREDENTIAL));
 
-        if (!isPasswordMatch(member, rawPassword)) {
+        if (!member.getPassword().equals(password)) {
             throw new MemberException(MemberErrorCode.INVALID_MEMBER_CREDENTIAL);
         }
 
         return member;
     }
 
-    private void validateNicknameUnique(String nickname) {
-        memberRepository.findByNickname(nickname)
-                .ifPresent(existingMember -> {
-                    throw new MemberException(MemberErrorCode.DUPLICATE_NICKNAME);
-                });
-    }
+    @Transactional
+    public void changePassword(
+            Long memberId,
+            String currentPassword,
+            String newPassword,
+            String newPasswordConfirm
+    ) {
+        Member member = getById(memberId);
 
-    private boolean isPasswordMatch(Member member, String rawPassword) {
-        if (member.getPassword() == null || rawPassword == null) {
-            return false;
+        if (!member.getPassword().equals(currentPassword)) {
+            throw new MemberException(MemberErrorCode.INVALID_MEMBER_CREDENTIAL);
         }
 
-        return passwordEncoder.matches(rawPassword, member.getPassword());
+        if (!newPassword.equals(newPasswordConfirm)) {
+            throw new MemberException(MemberErrorCode.INVALID_MEMBER_CREDENTIAL);
+        }
+
+        member.changePassword(newPassword);
+    }
+
+    @Transactional
+    public void updateProfile(
+            Long memberId,
+            String nickname,
+            String profileImageUrl
+    ) {
+        Member member = getById(memberId);
+        member.updateProfile(nickname, profileImageUrl);
     }
 }

--- a/src/main/java/plango/member/exception/MemberErrorCode.java
+++ b/src/main/java/plango/member/exception/MemberErrorCode.java
@@ -12,6 +12,8 @@ public enum MemberErrorCode {
     INVALID_MEMBER_STATUS(HttpStatus.BAD_REQUEST, "Invalid member status"),
 
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용 중인 닉네임입니다."),
+    DUPLICATE_LOGIN_ID(HttpStatus.BAD_REQUEST, "이미 사용 중인 아이디입니다."),
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 사용 중인 이메일입니다."),
     PASSWORD_CHANGE_NOT_ALLOWED_FOR_SOCIAL_MEMBER(HttpStatus.BAD_REQUEST, "카카오 로그인 회원은 비밀번호를 변경할 수 없습니다."),
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다."),
     NEW_PASSWORD_CONFIRM_NOT_MATCH(HttpStatus.BAD_REQUEST, "새 비밀번호 확인이 일치하지 않습니다."),


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #57 

## 🔎 작업 내용

- 회원가입 기능 전체 구현
  - 이름(2자 이상), 닉네임(2-10자), 아이디(영문소문자+숫자 4-16자), 비밀번호(영문+숫자 6-20자), 이메일 형식 검증 적용
  - Bean Validation 기반 입력값 유효성 검증 추가
  - 닉네임 / 아이디 / 이메일 중복 확인 기능 구현
  - 중복 항목 존재 시 BusinessException 기반 예외 처리 적용 
- Member 엔티티에 changePassword() 누락되어 있던 부분 추가하여 빌드 오류 해결
- Swagger 기반 회원가입 및 중복확인 API 정상 작동 확인 (정상/오류 케이스 모두 테스트 완료)
<br>


## 📌 참고 사항

- 집중 리뷰 <!--(선택 사항)-->
    - 검증 규칙 또는 예외 코드 네이밍 관련 보완점 있는지 확인 부탁드립니다
    - Member 엔티티에 추가된 changePassword() 메서드 위치 및 구조 문제 없는지 검토 필요
- 기타 안내 사항 <!--(선택 사항)-->
    - 기존 회원 데이터는 중복 검증 테스트를 위해 일부 초기화 후 재생성하여 테스트 진행했습니다
    - Swagger 상에서 정상적으로 모든 API 검증 완료했습니다
- 주의해야 할 점 <!--(선택 사항)-->
    - 이메일/로그인아이디/닉네임 중복 체크 API가 각각 별도로 존재하므로, 프론트에서 호출 순서 고려 필요
    - 이름, 닉네임 등 모든 Validation은 서버 레벨에서도 강제 적용되어 있어 잘못된 입력값 전송 시 400 오류 발생합니다

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수