### PR TITLE
Feat/#32/여행방내실시간채팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	implementation 'org.springframework.security:spring-security-crypto'
+
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/plango/chat/application/dto/request/ChatMessageSendRequest.java
+++ b/src/main/java/plango/chat/application/dto/request/ChatMessageSendRequest.java
@@ -1,0 +1,14 @@
+package plango.chat.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ChatMessageSendRequest(
+        @NotNull(message = "회원 ID는 필수입니다.")
+        Long memberId,
+        @NotBlank(message = "메시지 내용은 필수입니다.")
+        @Size(max = 1000, message = "메시지는 최대 1000자까지 가능합니다.")
+        String content
+) {
+}

--- a/src/main/java/plango/chat/application/dto/response/ChatMessageResponse.java
+++ b/src/main/java/plango/chat/application/dto/response/ChatMessageResponse.java
@@ -1,0 +1,18 @@
+package plango.chat.application.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+public record ChatMessageResponse(
+        Long messageId,
+        Long roomId,
+        Long senderId,
+        String senderNickname,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    @Builder
+    public ChatMessageResponse {
+    }
+}

--- a/src/main/java/plango/chat/application/exception/ChatErrorCode.java
+++ b/src/main/java/plango/chat/application/exception/ChatErrorCode.java
@@ -1,0 +1,21 @@
+package plango.chat.application.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatErrorCode {
+
+    CHAT_MEMBER_NOT_IN_ROOM(HttpStatus.FORBIDDEN, "여행방 멤버만 채팅에 참여할 수 있습니다."),
+    CHAT_MESSAGE_EMPTY(HttpStatus.BAD_REQUEST, "메시지 내용은 비어 있을 수 없습니다.");
+
+    private final HttpStatus status;
+
+    private final String message;
+
+    public int getStatusCode() {
+        return status.value();
+    }
+}

--- a/src/main/java/plango/chat/application/exception/ChatException.java
+++ b/src/main/java/plango/chat/application/exception/ChatException.java
@@ -1,0 +1,15 @@
+package plango.chat.application.exception;
+
+import lombok.Getter;
+import plango.global.common.exception.BusinessException;
+
+@Getter
+public class ChatException extends BusinessException {
+
+    private final ChatErrorCode errorCode;
+
+    public ChatException(ChatErrorCode errorCode) {
+        super(errorCode.getStatusCode(), errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/plango/chat/application/mapper/ChatMessageMapper.java
+++ b/src/main/java/plango/chat/application/mapper/ChatMessageMapper.java
@@ -1,0 +1,28 @@
+package plango.chat.application.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import plango.chat.application.dto.response.ChatMessageResponse;
+import plango.chat.domain.entity.ChatMessage;
+
+@Component
+public class ChatMessageMapper {
+
+    public ChatMessageResponse toResponse(ChatMessage chatMessage) {
+        return ChatMessageResponse.builder()
+                .messageId(chatMessage.getId())
+                .roomId(chatMessage.getRoom().getId())
+                .senderId(chatMessage.getSender().getId())
+                .senderNickname(chatMessage.getSender().getNickname())
+                .content(chatMessage.getContent())
+                .createdAt(chatMessage.getCreatedAt())
+                .build();
+    }
+
+    public List<ChatMessageResponse> toResponseList(List<ChatMessage> messages) {
+        return messages.stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/plango/chat/application/usecase/ChatMessageHistoryBeforeQueryUseCase.java
+++ b/src/main/java/plango/chat/application/usecase/ChatMessageHistoryBeforeQueryUseCase.java
@@ -1,0 +1,42 @@
+package plango.chat.application.usecase;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.chat.application.dto.response.ChatMessageResponse;
+import plango.chat.application.mapper.ChatMessageMapper;
+import plango.chat.domain.entity.ChatMessage;
+import plango.chat.domain.service.ChatMessageService;
+import plango.room.domain.service.RoomGetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatMessageHistoryBeforeQueryUseCase {
+
+    private final ChatMessageService chatMessageService;
+
+    private final ChatMessageMapper chatMessageMapper;
+
+    private final RoomGetService roomGetService;
+
+    public List<ChatMessageResponse> execute(
+            Long roomId,
+            Long beforeMessageId,
+            int size
+    ) {
+        roomGetService.getRoomById(roomId);
+
+        List<ChatMessage> messages = chatMessageService.getMessagesBefore(
+                roomId,
+                beforeMessageId,
+                size
+        );
+
+        Collections.reverse(messages);
+
+        return chatMessageMapper.toResponseList(messages);
+    }
+}

--- a/src/main/java/plango/chat/application/usecase/ChatMessageHistoryQueryUseCase.java
+++ b/src/main/java/plango/chat/application/usecase/ChatMessageHistoryQueryUseCase.java
@@ -1,0 +1,34 @@
+package plango.chat.application.usecase;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.chat.application.dto.response.ChatMessageResponse;
+import plango.chat.application.mapper.ChatMessageMapper;
+import plango.chat.domain.entity.ChatMessage;
+import plango.chat.domain.service.ChatMessageService;
+import plango.room.domain.service.RoomGetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatMessageHistoryQueryUseCase {
+
+    private final ChatMessageService chatMessageService;
+
+    private final ChatMessageMapper chatMessageMapper;
+
+    private final RoomGetService roomGetService;
+
+    public List<ChatMessageResponse> execute(Long roomId) {
+        roomGetService.getRoomById(roomId);
+
+        List<ChatMessage> messages = chatMessageService.getLatestMessages(roomId);
+
+        Collections.reverse(messages);
+
+        return chatMessageMapper.toResponseList(messages);
+    }
+}

--- a/src/main/java/plango/chat/application/usecase/ChatMessageSendUseCase.java
+++ b/src/main/java/plango/chat/application/usecase/ChatMessageSendUseCase.java
@@ -1,0 +1,55 @@
+package plango.chat.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.chat.application.dto.request.ChatMessageSendRequest;
+import plango.chat.application.dto.response.ChatMessageResponse;
+import plango.chat.application.exception.ChatErrorCode;
+import plango.chat.application.exception.ChatException;
+import plango.chat.application.mapper.ChatMessageMapper;
+import plango.chat.domain.entity.ChatMessage;
+import plango.chat.domain.service.ChatMessageService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberGetService;
+import plango.room.domain.entity.Room;
+import plango.room.domain.repository.RoomMemberRepository;
+import plango.room.domain.service.RoomGetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatMessageSendUseCase {
+
+    private final ChatMessageService chatMessageService;
+
+    private final ChatMessageMapper chatMessageMapper;
+
+    private final RoomGetService roomGetService;
+
+    private final MemberGetService memberGetService;
+
+    private final RoomMemberRepository roomMemberRepository;
+
+    @Transactional
+    public ChatMessageResponse execute(Long roomId, ChatMessageSendRequest request) {
+        Room room = roomGetService.getRoomById(roomId);
+        Member sender = memberGetService.getById(request.memberId());
+
+        boolean isMember = roomMemberRepository.existsByRoomAndMemberId(room, sender.getId());
+
+        if (!isMember) {
+            throw new ChatException(ChatErrorCode.CHAT_MEMBER_NOT_IN_ROOM);
+        }
+
+        ChatMessage chatMessage = new ChatMessage(
+                room,
+                sender,
+                request.content()
+        );
+
+        ChatMessage saved = chatMessageService.save(chatMessage);
+
+        return chatMessageMapper.toResponse(saved);
+    }
+}

--- a/src/main/java/plango/chat/domain/entity/ChatMessage.java
+++ b/src/main/java/plango/chat/domain/entity/ChatMessage.java
@@ -1,0 +1,43 @@
+package plango.chat.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import plango.global.common.entity.BaseTimeEntity;
+import plango.member.domain.entity.Member;
+import plango.room.domain.entity.Room;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id", nullable = false)
+    private Member sender;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    public ChatMessage(Room room, Member sender, String content) {
+        this.room = room;
+        this.sender = sender;
+        this.content = content;
+    }
+}

--- a/src/main/java/plango/chat/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/plango/chat/domain/repository/ChatMessageRepository.java
@@ -8,4 +8,10 @@ import plango.chat.domain.entity.ChatMessage;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     List<ChatMessage> findByRoomIdOrderByIdDesc(Long roomId, Pageable pageable);
+
+    List<ChatMessage> findByRoomIdAndIdLessThanOrderByIdDesc(
+            Long roomId,
+            Long id,
+            Pageable pageable
+    );
 }

--- a/src/main/java/plango/chat/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/plango/chat/domain/repository/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package plango.chat.domain.repository;
+
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import plango.chat.domain.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    List<ChatMessage> findByRoomIdOrderByIdDesc(Long roomId, Pageable pageable);
+}

--- a/src/main/java/plango/chat/domain/service/ChatMessageService.java
+++ b/src/main/java/plango/chat/domain/service/ChatMessageService.java
@@ -31,4 +31,23 @@ public class ChatMessageService {
         );
         return chatMessageRepository.findByRoomIdOrderByIdDesc(roomId, pageRequest);
     }
+
+    public List<ChatMessage> getMessagesBefore(
+            Long roomId,
+            Long beforeMessageId,
+            int size
+    ) {
+        int pageSize = size > 0 ? size : DEFAULT_PAGE_SIZE;
+
+        PageRequest pageRequest = PageRequest.of(
+                0,
+                pageSize,
+                Sort.by(Sort.Direction.DESC, "id")
+        );
+        return chatMessageRepository.findByRoomIdAndIdLessThanOrderByIdDesc(
+                roomId,
+                beforeMessageId,
+                pageRequest
+        );
+    }
 }

--- a/src/main/java/plango/chat/domain/service/ChatMessageService.java
+++ b/src/main/java/plango/chat/domain/service/ChatMessageService.java
@@ -1,0 +1,34 @@
+package plango.chat.domain.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.chat.domain.entity.ChatMessage;
+import plango.chat.domain.repository.ChatMessageRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatMessageService {
+
+    private static final int DEFAULT_PAGE_SIZE = 50;
+
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public ChatMessage save(ChatMessage chatMessage) {
+        return chatMessageRepository.save(chatMessage);
+    }
+
+    public List<ChatMessage> getLatestMessages(Long roomId) {
+        PageRequest pageRequest = PageRequest.of(
+                0,
+                DEFAULT_PAGE_SIZE,
+                Sort.by(Sort.Direction.DESC, "id")
+        );
+        return chatMessageRepository.findByRoomIdOrderByIdDesc(roomId, pageRequest);
+    }
+}

--- a/src/main/java/plango/chat/presentation/ChatMessageController.java
+++ b/src/main/java/plango/chat/presentation/ChatMessageController.java
@@ -1,0 +1,63 @@
+package plango.chat.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import plango.chat.application.dto.request.ChatMessageSendRequest;
+import plango.chat.application.dto.response.ChatMessageResponse;
+import plango.chat.application.usecase.ChatMessageHistoryQueryUseCase;
+import plango.chat.application.usecase.ChatMessageSendUseCase;
+import plango.global.common.response.CommonResponse;
+import plango.global.common.response.ResponseMessage;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rooms/{roomId}/chats")
+@Tag(name = "Room Chat", description = "여행방 내 실시간 채팅 API")
+public class ChatMessageController {
+
+    private final ChatMessageSendUseCase chatMessageSendUseCase;
+
+    private final ChatMessageHistoryQueryUseCase chatMessageHistoryQueryUseCase;
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @PostMapping
+    @Operation(
+            summary = "채팅 메시지 전송",
+            description = "여행방 멤버가 채팅 메시지를 전송합니다. 성공 시 WebSocket 구독자에게도 브로드캐스트됩니다."
+    )
+    public CommonResponse<ChatMessageResponse> sendMessage(
+            @PathVariable Long roomId,
+            @Valid @RequestBody ChatMessageSendRequest request
+    ) {
+        ChatMessageResponse response = chatMessageSendUseCase.execute(roomId, request);
+
+        String destination = "/topic/rooms/" + roomId;
+
+        messagingTemplate.convertAndSend(destination, response);
+
+        return CommonResponse.success(ResponseMessage.CHAT_MESSAGE_SEND_SUCCESS, response);
+    }
+
+    @GetMapping
+    @Operation(
+            summary = "채팅 메시지 목록 조회",
+            description = "여행방의 최근 채팅 메시지 목록을 조회합니다. 기본 50개까지 조회합니다."
+    )
+    public CommonResponse<List<ChatMessageResponse>> getMessages(
+            @PathVariable Long roomId
+    ) {
+        List<ChatMessageResponse> responses = chatMessageHistoryQueryUseCase.execute(roomId);
+        return CommonResponse.success(ResponseMessage.CHAT_MESSAGE_LIST_GET_SUCCESS, responses);
+    }
+}

--- a/src/main/java/plango/chat/presentation/ChatMessageController.java
+++ b/src/main/java/plango/chat/presentation/ChatMessageController.java
@@ -11,9 +11,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import plango.chat.application.dto.request.ChatMessageSendRequest;
 import plango.chat.application.dto.response.ChatMessageResponse;
+import plango.chat.application.usecase.ChatMessageHistoryBeforeQueryUseCase;
 import plango.chat.application.usecase.ChatMessageHistoryQueryUseCase;
 import plango.chat.application.usecase.ChatMessageSendUseCase;
 import plango.global.common.response.CommonResponse;
@@ -29,12 +31,14 @@ public class ChatMessageController {
 
     private final ChatMessageHistoryQueryUseCase chatMessageHistoryQueryUseCase;
 
+    private final ChatMessageHistoryBeforeQueryUseCase chatMessageHistoryBeforeQueryUseCase;
+
     private final SimpMessagingTemplate messagingTemplate;
 
     @PostMapping
     @Operation(
             summary = "채팅 메시지 전송",
-            description = "여행방 멤버가 채팅 메시지를 전송합니다. 성공 시 WebSocket 구독자에게도 브로드캐스트됩니다."
+            description = "여행방 멤버가 채팅 메시지를 전송합니다."
     )
     public CommonResponse<ChatMessageResponse> sendMessage(
             @PathVariable Long roomId,
@@ -59,5 +63,24 @@ public class ChatMessageController {
     ) {
         List<ChatMessageResponse> responses = chatMessageHistoryQueryUseCase.execute(roomId);
         return CommonResponse.success(ResponseMessage.CHAT_MESSAGE_LIST_GET_SUCCESS, responses);
+    }
+
+    @GetMapping("/history")
+    @Operation(
+            summary = "채팅 이전 메시지 조회",
+            description = "현재 가장 오래된 메시지 ID 기준으로 그 이전 메시지들을 조회합니다."
+    )
+    public CommonResponse<List<ChatMessageResponse>> getMessagesBefore(
+            @PathVariable Long roomId,
+            @RequestParam Long beforeMessageId,
+            @RequestParam(required = false, defaultValue = "50") int size
+    ) {
+        List<ChatMessageResponse> responses =
+                chatMessageHistoryBeforeQueryUseCase.execute(roomId, beforeMessageId, size);
+
+        return CommonResponse.success(
+                ResponseMessage.CHAT_MESSAGE_HISTORY_BEFORE_GET_SUCCESS,
+                responses
+        );
     }
 }

--- a/src/main/java/plango/chat/presentation/ChatWebSocketController.java
+++ b/src/main/java/plango/chat/presentation/ChatWebSocketController.java
@@ -1,0 +1,31 @@
+package plango.chat.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import plango.chat.application.dto.request.ChatMessageSendRequest;
+import plango.chat.application.dto.response.ChatMessageResponse;
+import plango.chat.application.usecase.ChatMessageSendUseCase;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatWebSocketController {
+
+    private final ChatMessageSendUseCase chatMessageSendUseCase;
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/rooms/{roomId}")
+    public void sendChatMessage(
+            @DestinationVariable Long roomId,
+            ChatMessageSendRequest request
+    ) {
+        ChatMessageResponse response = chatMessageSendUseCase.execute(roomId, request);
+
+        String destination = "/topic/rooms/" + roomId;
+
+        messagingTemplate.convertAndSend(destination, response);
+    }
+}

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -51,7 +51,11 @@ public enum ResponseMessage {
     FRIEND_TARGET_NOT_FOUND(0, "해당 닉네임의 사용자를 찾을 수 없습니다."),
     FRIEND_ACCEPT_SUCCESS(0, "친구 요청 수락 성공"),
     FRIEND_REJECT_SUCCESS(0, "친구 요청 거절 성공"),
-    FRIEND_CANCEL_SUCCESS(0, "친구 요청 취소 성공");
+    FRIEND_CANCEL_SUCCESS(0, "친구 요청 취소 성공"),
+
+    // ===== 채팅 =====
+    CHAT_MESSAGE_SEND_SUCCESS(0, "채팅 메시지 전송 성공"),
+    CHAT_MESSAGE_LIST_GET_SUCCESS(0, "채팅 메시지 목록 조회 성공");
 
     private final int code;
     private final String message;

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -55,7 +55,8 @@ public enum ResponseMessage {
 
     // ===== 채팅 =====
     CHAT_MESSAGE_SEND_SUCCESS(0, "채팅 메시지 전송 성공"),
-    CHAT_MESSAGE_LIST_GET_SUCCESS(0, "채팅 메시지 목록 조회 성공");
+    CHAT_MESSAGE_LIST_GET_SUCCESS(0, "채팅 메시지 목록 조회 성공"),
+    CHAT_MESSAGE_HISTORY_BEFORE_GET_SUCCESS(0, "채팅 이전 메시지 목록 조회 성공");
 
     private final int code;
     private final String message;

--- a/src/main/java/plango/global/config/WebSocketConfig.java
+++ b/src/main/java/plango/global/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package plango.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOriginPatterns("*");
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/src/main/resources/db/migration/V20__create_chat_message_table.sql
+++ b/src/main/resources/db/migration/V20__create_chat_message_table.sql
@@ -1,0 +1,22 @@
+CREATE TABLE chat_message (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+
+    room_id BIGINT NOT NULL,
+    sender_id BIGINT NOT NULL,
+
+    content VARCHAR(1000) NOT NULL,
+
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NULL,
+
+    CONSTRAINT fk_chat_message_room
+        FOREIGN KEY (room_id) REFERENCES room(id)
+            ON DELETE CASCADE,
+
+    CONSTRAINT fk_chat_message_member
+        FOREIGN KEY (sender_id) REFERENCES member(id)
+            ON DELETE CASCADE
+);
+
+CREATE INDEX idx_chat_message_room_created_at
+    ON chat_message (room_id, created_at);


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #65 

## 🔎 작업 내용

- 여행방 내 실시간 채팅(STOMP WebSocket) 기능 구현

  - /ws/chat WebSocket 엔드포인트 추가

  - /app/rooms/{roomId} 메시지 송신

  - /topic/rooms/{roomId} 실시간 메시지 구독 채널 구현

  - 웹소켓 메시지 수신 시 동일한 구조로 모든 클라이언트에 브로드캐스트

- 채팅 메시지 DB 저장 기능 구현

  -  chat_message 테이블 생성 (Flyway 적용)

  - Room / Member FK 연동

  - 메시지 내용, 보낸 시간 저장

- REST 기반 채팅 API 구현

  - POST /api/rooms/{roomId}/chats : 채팅 메시지 전송

  - GET /api/rooms/{roomId}/chats : 최신 50개 메시지 조회

- 이전 메시지 불러오기 API 추가 (무한 스크롤 지원)

  - GET /api/rooms/{roomId}/chats/history?beforeMessageId={id}

  - 기준 메시지 이전 메시지 페이징 방식으로 조회

  - 프론트에서 스크롤 업 시 이전 메시지 추가 로딩 가능하도록 설계

- 채팅 관련 DTO / Mapper / UseCase 계층 구현

  - 백엔드 구조 컨벤션 준수(application / domain / presentation)

- ResponseMessage enum에 채팅용 응답 코드 추가

  - CHAT_MESSAGE_SEND_SUCCESS

  - CHAT_MESSAGE_LIST_GET_SUCCESS

  - CHAT_MESSAGE_HISTORY_BEFORE_GET_SUCCESS

- WebSocketConfig 추가

  - SimpleBroker 활성화

  - CORS 허용 설정

  - 클라이언트 연결 호환성 확보

<br>


## 📌 참고 사항

- 테스트 결과
  - Swagger에서 실시간 메시지 저장/조회 모두 정상 동작
  - 이전 메시지 불러오기 API 또한 정상적으로 데이터 반환 확인
  - WebSocket 실시간 송수신 테스트 성공
- 프론트 적용 가이드
  - 방 입장 시 → 최신 50개 조회
  - 스크롤 위로 이동 시 → beforeMessageId 기반 API 호출
  - WebSocket 구독으로 새 메시지 push 이벤트 처리

<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수