### PR TITLE
Feat/#33/회원 탈퇴

### DIFF
--- a/src/main/java/plango/auth/domain/repository/SocialAccountRepository.java
+++ b/src/main/java/plango/auth/domain/repository/SocialAccountRepository.java
@@ -17,4 +17,6 @@ public interface SocialAccountRepository extends JpaRepository<SocialAccount, Lo
             String provider,
             Collection<String> providerUserIds
     );
+
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/plango/auth/domain/service/SocialAccountService.java
+++ b/src/main/java/plango/auth/domain/service/SocialAccountService.java
@@ -48,4 +48,9 @@ public class SocialAccountService {
         SocialAccount socialAccount = SocialAccount.createKakaoAccount(providerUserId, member);
         return socialAccountRepository.save(socialAccount);
     }
+
+    @Transactional
+    public void deleteByMemberId(Long memberId) {
+        socialAccountRepository.deleteByMemberId(memberId);
+    }
 }

--- a/src/main/java/plango/friend/domain/repository/FriendRepository.java
+++ b/src/main/java/plango/friend/domain/repository/FriendRepository.java
@@ -17,4 +17,7 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     );
 
     Optional<Friend> findByRequesterAndReceiver(Member requester, Member receiver);
+
+    void deleteAllByRequesterOrReceiver(Member requester, Member receiver);
 }
+

--- a/src/main/java/plango/friend/domain/service/FriendService.java
+++ b/src/main/java/plango/friend/domain/service/FriendService.java
@@ -93,4 +93,9 @@ public class FriendService {
             throw new FriendException(FriendErrorCode.FRIEND_REQUEST_ALREADY_EXISTS);
         }
     }
+
+    @Transactional
+    public void deleteAllByMember(Member member) {
+        friendRepository.deleteAllByRequesterOrReceiver(member, member);
+    }
 }

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -11,6 +11,7 @@ public enum ResponseMessage {
     SUCCESS(0, "성공"),
 
     MEMBER_SIGN_UP_SUCCESS(0, "회원가입 성공"),
+    MEMBER_WITHDRAW_SUCCESS(0, "회원 탈퇴 성공"),
 
     MEMBER_NICKNAME_CHECK_SUCCESS(0, "닉네임 중복 확인 성공"),
     MEMBER_LOGIN_ID_CHECK_SUCCESS(0, "아이디 중복 확인 성공"),

--- a/src/main/java/plango/member/application/usecase/MemberWithdrawUseCase.java
+++ b/src/main/java/plango/member/application/usecase/MemberWithdrawUseCase.java
@@ -1,0 +1,29 @@
+package plango.member.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.domain.service.SocialAccountService;
+import plango.friend.domain.service.FriendService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberGetService;
+import plango.member.domain.service.MemberService;
+
+@Service
+@RequiredArgsConstructor
+public class MemberWithdrawUseCase {
+
+    private final MemberGetService memberGetService;
+    private final MemberService memberService;
+    private final SocialAccountService socialAccountService;
+    private final FriendService friendService;
+
+    @Transactional
+    public void execute(Long memberId) {
+        Member member = memberGetService.getById(memberId);
+
+        friendService.deleteAllByMember(member);
+        socialAccountService.deleteByMemberId(member.getId());
+        memberService.deleteById(member.getId());
+    }
+}

--- a/src/main/java/plango/member/domain/service/MemberService.java
+++ b/src/main/java/plango/member/domain/service/MemberService.java
@@ -93,4 +93,11 @@ public class MemberService {
         Member member = getById(memberId);
         member.updateProfile(nickname, profileImageUrl);
     }
+
+    @Transactional
+    public void deleteById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+        memberRepository.delete(member);
+    }
 }

--- a/src/main/java/plango/member/presentation/MemberController.java
+++ b/src/main/java/plango/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 import plango.member.application.dto.request.MemberProfileUpdateRequest;
@@ -15,6 +16,7 @@ import plango.member.application.dto.response.MemberProfileResponse;
 import plango.member.application.usecase.GetMyProfileUseCase;
 import plango.member.application.usecase.UpdateMyProfileUseCase;
 import plango.member.application.usecase.ChangePasswordUseCase;
+import plango.member.application.usecase.MemberWithdrawUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -28,6 +30,7 @@ public class MemberController {
     private final GetMyProfileUseCase getMyProfileUseCase;
     private final UpdateMyProfileUseCase updateMyProfileUseCase;
     private final ChangePasswordUseCase changePasswordUseCase;
+    private final MemberWithdrawUseCase memberWithdrawUseCase;
 
     @Operation(summary = "프로필 조회", description = "memberId를 기준으로 프로필 정보를 조회합니다.")
     @GetMapping("/{memberId}")
@@ -50,6 +53,20 @@ public class MemberController {
         updateMyProfileUseCase.execute(memberId, request);
         return CommonResponse.success(
                 ResponseMessage.MEMBER_PROFILE_UPDATE_SUCCESS
+        );
+    }
+
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "회원의 계정 및 연관 데이터를 모두 삭제합니다. (소셜 계정, 친구 관계, 여행방 등)"
+    )
+    @DeleteMapping("/{memberId}")
+    public CommonResponse<Void> withdraw(
+            @PathVariable Long memberId
+    ) {
+        memberWithdrawUseCase.execute(memberId);
+        return CommonResponse.success(
+                ResponseMessage.MEMBER_WITHDRAW_SUCCESS
         );
     }
 


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #67

## 🔎 작업 내용

- 회원 탈퇴 기능 구현
  - `DELETE /members/{memberId}` API 추가
  - 회원 탈퇴 시 연관된 모든 도메인 데이터 삭제
    - 친구 관계(Friend): requester / receiver 에 해당하는 모든 레코드 삭제
    - 카카오 소셜 계정(SocialAccount): memberId 기준 삭제
    - member 삭제 시 cascade 되는 데이터 확인 (room, room_member, chat_message 등)
  - MemberWithdrawUseCase 추가
    - FriendService, SocialAccountService, MemberService 조합하여 탈퇴 프로세스 수행
  - MemberController 에 회원탈퇴 엔드포인트 추가
  - ResponseMessage 에 `MEMBER_WITHDRAW_SUCCESS` 추가
- 스웨거 테스트 완료
  - 정상 흐름: 탈퇴 요청 → 친구/소셜/멤버 데이터 삭제 확인
  - 존재하지 않는 memberId 요청 시 MemberException 정상 반환 확인

<br>

## 📌 참고 사항

- 집중 리뷰
    - 엔티티 관계 기준으로 cascade delete 구조가 맞는지 한 번 더 검토 부탁드립니다.
- 기타 안내 사항
    - 소셜 로그인 회원, 일반 회원 동일한 로직으로 처리됩니다.
- 주의해야 할 점
    - 탈퇴 후 해당 memberId 로의 로그인/프로필 조회 요청 시 반드시 MEMBER_NOT_FOUND 예외가 발생해야 합니다.


<!-- 내용이 없을 경우 해당 항목은 삭제해 주세요 -->

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수