### PR TITLE
Feat/#34/아이디 찾기

### DIFF
--- a/src/main/java/plango/auth/application/dto/request/FindLoginIdRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/FindLoginIdRequest.java
@@ -1,0 +1,11 @@
+package plango.auth.application.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record FindLoginIdRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        String email
+) {
+}

--- a/src/main/java/plango/auth/application/dto/request/VerifyLoginIdCodeRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/VerifyLoginIdCodeRequest.java
@@ -1,0 +1,16 @@
+package plango.auth.application.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record VerifyLoginIdCodeRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "인증번호는 필수입니다.")
+        @Pattern(regexp = "^[0-9]{6}$", message = "인증번호는 6자리 숫자여야 합니다.")
+        String code
+) {
+}

--- a/src/main/java/plango/auth/application/dto/response/FindLoginIdPreviewResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/FindLoginIdPreviewResponse.java
@@ -1,0 +1,14 @@
+package plango.auth.application.dto.response;
+
+public record FindLoginIdPreviewResponse(
+        String email,
+        String maskedLoginId
+) {
+
+    public static FindLoginIdPreviewResponse of(
+            String email,
+            String maskedLoginId
+    ) {
+        return new FindLoginIdPreviewResponse(email, maskedLoginId);
+    }
+}

--- a/src/main/java/plango/auth/application/dto/response/FindLoginIdResultResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/FindLoginIdResultResponse.java
@@ -1,0 +1,10 @@
+package plango.auth.application.dto.response;
+
+public record FindLoginIdResultResponse(
+        String loginId
+) {
+
+    public static FindLoginIdResultResponse from(String loginId) {
+        return new FindLoginIdResultResponse(loginId);
+    }
+}

--- a/src/main/java/plango/auth/application/dto/response/SendLoginIdVerificationCodeResponse.java
+++ b/src/main/java/plango/auth/application/dto/response/SendLoginIdVerificationCodeResponse.java
@@ -1,0 +1,20 @@
+package plango.auth.application.dto.response;
+
+public record SendLoginIdVerificationCodeResponse(
+        String email,
+        String maskedEmail,
+        String verificationCode
+) {
+
+    public static SendLoginIdVerificationCodeResponse of(
+            String email,
+            String maskedEmail,
+            String verificationCode
+    ) {
+        return new SendLoginIdVerificationCodeResponse(
+                email,
+                maskedEmail,
+                verificationCode
+        );
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/FindLoginIdUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/FindLoginIdUseCase.java
@@ -1,0 +1,47 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.request.FindLoginIdRequest;
+import plango.auth.application.dto.response.FindLoginIdPreviewResponse;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberService;
+import plango.member.exception.MemberErrorCode;
+import plango.member.exception.MemberException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindLoginIdUseCase {
+
+    private static final int MASK_SIZE = 5;
+
+    private final MemberService memberService;
+
+    public FindLoginIdPreviewResponse execute(FindLoginIdRequest request) {
+        Member member = memberService.findByEmail(request.email())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        String maskedLoginId = maskLoginId(member.getLoginId());
+
+        return FindLoginIdPreviewResponse.of(request.email(), maskedLoginId);
+    }
+
+    private String maskLoginId(String loginId) {
+        if (loginId == null || loginId.isBlank()) {
+            return "";
+        }
+
+        if (loginId.length() <= MASK_SIZE) {
+            return "*".repeat(loginId.length());
+        }
+
+        int visibleLength = loginId.length() - MASK_SIZE;
+
+        String visible = loginId.substring(0, visibleLength);
+        String masked = "*".repeat(MASK_SIZE);
+
+        return visible + masked;
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/SendLoginIdVerificationCodeUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/SendLoginIdVerificationCodeUseCase.java
@@ -1,0 +1,36 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.request.FindLoginIdRequest;
+import plango.auth.application.dto.response.SendLoginIdVerificationCodeResponse;
+import plango.auth.domain.service.EmailVerificationService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberService;
+import plango.member.exception.MemberErrorCode;
+import plango.member.exception.MemberException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SendLoginIdVerificationCodeUseCase {
+
+    private final MemberService memberService;
+
+    private final EmailVerificationService emailVerificationService;
+
+    public SendLoginIdVerificationCodeResponse execute(FindLoginIdRequest request) {
+        Member member = memberService.findByEmail(request.email())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        String code = emailVerificationService.createAndSendVerificationCode(member.getEmail());
+        String maskedEmail = emailVerificationService.maskEmail(member.getEmail());
+
+        return SendLoginIdVerificationCodeResponse.of(
+                member.getEmail(),
+                maskedEmail,
+                code
+        );
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/VerifyLoginIdCodeUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/VerifyLoginIdCodeUseCase.java
@@ -1,0 +1,31 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.request.VerifyLoginIdCodeRequest;
+import plango.auth.application.dto.response.FindLoginIdResultResponse;
+import plango.auth.domain.service.EmailVerificationService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberService;
+import plango.member.exception.MemberErrorCode;
+import plango.member.exception.MemberException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VerifyLoginIdCodeUseCase {
+
+    private final MemberService memberService;
+
+    private final EmailVerificationService emailVerificationService;
+
+    public FindLoginIdResultResponse execute(VerifyLoginIdCodeRequest request) {
+        emailVerificationService.verifyCode(request.email(), request.code());
+
+        Member member = memberService.findByEmail(request.email())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        return FindLoginIdResultResponse.from(member.getLoginId());
+    }
+}

--- a/src/main/java/plango/auth/domain/service/EmailVerificationService.java
+++ b/src/main/java/plango/auth/domain/service/EmailVerificationService.java
@@ -1,0 +1,102 @@
+package plango.auth.domain.service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import plango.global.common.exception.BusinessException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private static final long EXPIRATION_MILLIS = 5 * 60 * 1000L;
+
+    private final Map<String, VerificationInfo> store = new ConcurrentHashMap<>();
+
+    public String createAndSendVerificationCode(String email) {
+        String code = generateCode();
+
+        VerificationInfo info = new VerificationInfo(code, Instant.now());
+        store.put(email, info);
+
+        log.info("[EmailVerification] email = {}, code = {}", email, code);
+
+        return code;
+    }
+
+    public void verifyCode(String email, String code) {
+        VerificationInfo info = store.get(email);
+
+        if (info == null) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST.value(),
+                    "인증번호가 존재하지 않습니다."
+            );
+        }
+
+        if (!info.code.equals(code)) {
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST.value(),
+                    "인증번호가 일치하지 않습니다."
+            );
+        }
+
+        Instant now = Instant.now();
+
+        if (now.isAfter(info.createdAt.plusMillis(EXPIRATION_MILLIS))) {
+            store.remove(email);
+
+            throw new BusinessException(
+                    HttpStatus.BAD_REQUEST.value(),
+                    "인증번호 유효 시간이 만료되었습니다."
+            );
+        }
+
+        store.remove(email);
+    }
+
+    private String generateCode() {
+        int value = ThreadLocalRandom.current().nextInt(0, 1_000_000);
+
+        return String.format("%06d", value);
+    }
+
+    public String maskEmail(String email) {
+        if (email == null || email.isBlank()) {
+            return "";
+        }
+
+        int atIndex = email.indexOf('@');
+
+        if (atIndex <= 0) {
+            return email;
+        }
+
+        String local = email.substring(0, atIndex);
+        String domain = email.substring(atIndex);
+
+        if (local.length() <= 2) {
+            return "**" + domain;
+        }
+
+        String visible = local.substring(0, 2);
+        String masked = "*".repeat(local.length() - 2);
+
+        return visible + masked + domain;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    private static class VerificationInfo {
+
+        private final String code;
+        private final Instant createdAt;
+    }
+}

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -18,9 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 import plango.auth.application.dto.request.KakaoLoginRequest;
 import plango.auth.application.dto.request.MemberLoginRequest;
 import plango.auth.application.dto.request.MemberSignUpRequest;
+import plango.auth.application.dto.request.FindLoginIdRequest;
+import plango.auth.application.dto.request.VerifyLoginIdCodeRequest;
 import plango.auth.application.dto.response.DuplicateCheckResponse;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.dto.response.MemberSignUpResponse;
+import plango.auth.application.dto.response.FindLoginIdPreviewResponse;
+import plango.auth.application.dto.response.FindLoginIdResultResponse;
+import plango.auth.application.dto.response.SendLoginIdVerificationCodeResponse;
 import plango.auth.application.usecase.EmailDuplicateCheckUseCase;
 import plango.auth.application.usecase.KakaoLoginUseCase;
 import plango.auth.application.usecase.LoginIdDuplicateCheckUseCase;
@@ -28,6 +33,9 @@ import plango.auth.application.usecase.LogoutUseCase;
 import plango.auth.application.usecase.MemberLoginUseCase;
 import plango.auth.application.usecase.MemberSignUpUseCase;
 import plango.auth.application.usecase.NicknameDuplicateCheckUseCase;
+import plango.auth.application.usecase.FindLoginIdUseCase;
+import plango.auth.application.usecase.SendLoginIdVerificationCodeUseCase;
+import plango.auth.application.usecase.VerifyLoginIdCodeUseCase;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
@@ -44,6 +52,10 @@ public class AuthController {
     private final MemberLoginUseCase memberLoginUseCase;
     private final KakaoLoginUseCase kakaoLoginUseCase;
     private final LogoutUseCase logoutUseCase;
+    private final FindLoginIdUseCase findLoginIdUseCase;
+    private final SendLoginIdVerificationCodeUseCase sendLoginIdVerificationCodeUseCase;
+    private final VerifyLoginIdCodeUseCase verifyLoginIdCodeUseCase;
+
 
     @Operation(summary = "일반 회원가입", description = "이름, 닉네임, 아이디, 비밀번호, 이메일로 회원가입합니다.")
     @PostMapping("/signup")
@@ -135,6 +147,60 @@ public class AuthController {
         DuplicateCheckResponse response = emailDuplicateCheckUseCase.execute(email);
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.MEMBER_EMAIL_CHECK_SUCCESS, response)
+        );
+    }
+
+    @Operation(
+            summary = "아이디 찾기 (마스킹)",
+            description = "회원가입 시 사용한 이메일로 아이디를 조회하고, 뒤 5자리를 마스킹한 아이디를 반환합니다."
+    )
+    @PostMapping("/find-id")
+    public ResponseEntity<CommonResponse<FindLoginIdPreviewResponse>> findLoginId(
+            @Valid
+            @RequestBody
+            FindLoginIdRequest request
+    ) {
+        FindLoginIdPreviewResponse response = findLoginIdUseCase.execute(request);
+
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS, response)
+        );
+    }
+
+    @Operation(
+            summary = "아이디 찾기 추가 인증번호 발송",
+            description = "아이디를 찾기 위해 입력한 이메일로 6자리 인증번호를 전송합니다. "
+                    + "테스트 편의를 위해 응답에 인증번호가 함께 포함됩니다."
+    )
+    @PostMapping("/find-id/send-code")
+    public ResponseEntity<CommonResponse<SendLoginIdVerificationCodeResponse>> sendFindIdCode(
+            @Valid
+            @RequestBody
+            FindLoginIdRequest request
+    ) {
+        SendLoginIdVerificationCodeResponse response =
+                sendLoginIdVerificationCodeUseCase.execute(request);
+
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS, response)
+        );
+    }
+
+    @Operation(
+            summary = "아이디 찾기 인증번호 검증",
+            description = "이메일로 발송된 6자리 인증번호를 검증하고, 성공 시 전체 아이디를 반환합니다."
+    )
+    @PostMapping("/find-id/verify-code")
+    public ResponseEntity<CommonResponse<FindLoginIdResultResponse>> verifyFindIdCode(
+            @Valid
+            @RequestBody
+            VerifyLoginIdCodeRequest request
+    ) {
+        FindLoginIdResultResponse response =
+                verifyLoginIdCodeUseCase.execute(request);
+
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS, response)
         );
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #69 

## 🔎 작업 내용

- 아이디 찾기 기능 구현
  - 입력한 이메일 기반으로 회원 존재 여부 검증
  - 존재할 경우 뒤 5자리를 마스킹한 아이디 응답
  - 존재하지 않을 경우 MEMBER_NOT_FOUND 예외 반환

- 이메일 인증번호 발송 기능 구현
  - 6자리 인증번호 생성 후 서버 메모리에 저장
  - 테스트 환경을 위한 인증번호 로그 출력 및 응답 포함
  -  인증번호 5분 유효시간 관리

- 인증번호 검증 후 전체 아이디 반환 기능 구현
  - 이메일 + 인증번호 일치 여부 검증
  - 인증번호 만료/불일치 예외 처리
  - 검증 성공 시 회원의 전체 loginId 응답

- AuthController에 아이디 찾기 관련 3개 엔드포인트 추가
  - /api/auth/find-id
  - /api/auth/find-id/send-code
  - /api/auth/find-id/verify-code

<br>


## 📌 참고 사항

- 집중 리뷰
  - 인증번호 관리 로직에서 5분 유효시간 체크, 사용 후 즉시 삭제 구조가 적절한지 확인 필요
  - 응답 DTO 구조가 향후 실서비스(이메일 발송 적용 시)에도 확장성 있게 설계되었는지 검토 요청

- 기타 안내 사항
  - 현재 인증번호는 메일 발송이 아닌 로그 출력 방식으로 운영됨
  - 프론트와의 연동 시, 마스킹된 아이디 노출 규칙(뒤 5자리 * 처리) 동일하게 적용 필요

- 주의해야 할 점
  - 운영 환경에서 실제 이메일 발송을 적용할 경우 verificationCode 필드는 응답에서 제거해야 함
  - 인증번호 저장 로직이 서버 메모리 기반이므로 추후 Redis 등 외부 캐시에 올리는 방식도 고려할 것

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수