### PR TITLE
Feat/#35/비밀번호 찾기

### DIFF
--- a/src/main/java/plango/auth/application/dto/request/FindPasswordByLoginIdRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/FindPasswordByLoginIdRequest.java
@@ -1,0 +1,10 @@
+package plango.auth.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FindPasswordByLoginIdRequest(
+
+        @NotBlank(message = "아이디는 필수입니다.")
+        String loginId
+) {
+}

--- a/src/main/java/plango/auth/application/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,21 @@
+package plango.auth.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ResetPasswordRequest(
+
+        @NotBlank(message = "아이디는 필수입니다.")
+        String loginId,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^[A-Za-z0-9]{6,20}$",
+                message = "비밀번호는 영문 대소문자와 숫자 조합 6~20자여야 합니다."
+        )
+        String newPassword,
+
+        @NotBlank(message = "새 비밀번호 확인은 필수입니다.")
+        String newPasswordConfirm
+) {
+}

--- a/src/main/java/plango/auth/application/usecase/CheckLoginIdForPasswordResetUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/CheckLoginIdForPasswordResetUseCase.java
@@ -1,0 +1,19 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.request.FindPasswordByLoginIdRequest;
+import plango.member.domain.service.MemberPasswordResetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CheckLoginIdForPasswordResetUseCase {
+
+    private final MemberPasswordResetService memberPasswordResetService;
+
+    public void execute(FindPasswordByLoginIdRequest request) {
+        memberPasswordResetService.validateLoginId(request.loginId());
+    }
+}

--- a/src/main/java/plango/auth/application/usecase/ResetPasswordUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/ResetPasswordUseCase.java
@@ -1,0 +1,23 @@
+package plango.auth.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.auth.application.dto.request.ResetPasswordRequest;
+import plango.member.domain.service.MemberPasswordResetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ResetPasswordUseCase {
+
+    private final MemberPasswordResetService memberPasswordResetService;
+
+    public void execute(ResetPasswordRequest request) {
+        memberPasswordResetService.resetPassword(
+                request.loginId(),
+                request.newPassword(),
+                request.newPasswordConfirm()
+        );
+    }
+}

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -20,6 +20,8 @@ import plango.auth.application.dto.request.MemberLoginRequest;
 import plango.auth.application.dto.request.MemberSignUpRequest;
 import plango.auth.application.dto.request.FindLoginIdRequest;
 import plango.auth.application.dto.request.VerifyLoginIdCodeRequest;
+import plango.auth.application.dto.request.FindPasswordByLoginIdRequest;
+import plango.auth.application.dto.request.ResetPasswordRequest;
 import plango.auth.application.dto.response.DuplicateCheckResponse;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.dto.response.MemberSignUpResponse;
@@ -36,6 +38,8 @@ import plango.auth.application.usecase.NicknameDuplicateCheckUseCase;
 import plango.auth.application.usecase.FindLoginIdUseCase;
 import plango.auth.application.usecase.SendLoginIdVerificationCodeUseCase;
 import plango.auth.application.usecase.VerifyLoginIdCodeUseCase;
+import plango.auth.application.usecase.CheckLoginIdForPasswordResetUseCase;
+import plango.auth.application.usecase.ResetPasswordUseCase;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
@@ -55,7 +59,8 @@ public class AuthController {
     private final FindLoginIdUseCase findLoginIdUseCase;
     private final SendLoginIdVerificationCodeUseCase sendLoginIdVerificationCodeUseCase;
     private final VerifyLoginIdCodeUseCase verifyLoginIdCodeUseCase;
-
+    private final CheckLoginIdForPasswordResetUseCase checkLoginIdForPasswordResetUseCase;
+    private final ResetPasswordUseCase resetPasswordUseCase;
 
     @Operation(summary = "일반 회원가입", description = "이름, 닉네임, 아이디, 비밀번호, 이메일로 회원가입합니다.")
     @PostMapping("/signup")
@@ -65,6 +70,7 @@ public class AuthController {
             MemberSignUpRequest request
     ) {
         MemberSignUpResponse response = memberSignUpUseCase.execute(request);
+
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.MEMBER_SIGN_UP_SUCCESS, response)
         );
@@ -78,6 +84,7 @@ public class AuthController {
             MemberLoginRequest request
     ) {
         KakaoLoginResponse response = memberLoginUseCase.execute(request);
+
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.SUCCESS, response)
         );
@@ -91,6 +98,7 @@ public class AuthController {
             KakaoLoginRequest request
     ) {
         KakaoLoginResponse response = kakaoLoginUseCase.execute(request);
+
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.SUCCESS, response)
         );
@@ -100,6 +108,7 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<CommonResponse<Void>> logout() {
         logoutUseCase.execute();
+
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.SUCCESS)
         );
@@ -114,6 +123,7 @@ public class AuthController {
             String nickname
     ) {
         DuplicateCheckResponse response = nicknameDuplicateCheckUseCase.execute(nickname);
+
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.MEMBER_NICKNAME_CHECK_SUCCESS, response)
         );
@@ -131,6 +141,7 @@ public class AuthController {
             String loginId
     ) {
         DuplicateCheckResponse response = loginIdDuplicateCheckUseCase.execute(loginId);
+
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.MEMBER_LOGIN_ID_CHECK_SUCCESS, response)
         );
@@ -145,6 +156,7 @@ public class AuthController {
             String email
     ) {
         DuplicateCheckResponse response = emailDuplicateCheckUseCase.execute(email);
+
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.MEMBER_EMAIL_CHECK_SUCCESS, response)
         );
@@ -169,8 +181,7 @@ public class AuthController {
 
     @Operation(
             summary = "아이디 찾기 추가 인증번호 발송",
-            description = "아이디를 찾기 위해 입력한 이메일로 6자리 인증번호를 전송합니다. "
-                    + "테스트 편의를 위해 응답에 인증번호가 함께 포함됩니다."
+            description = "아이디를 찾기 위해 입력한 이메일로 6자리 인증번호를 전송합니다. 테스트 편의를 위해 응답에 인증번호가 함께 포함됩니다."
     )
     @PostMapping("/find-id/send-code")
     public ResponseEntity<CommonResponse<SendLoginIdVerificationCodeResponse>> sendFindIdCode(
@@ -201,6 +212,40 @@ public class AuthController {
 
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.SUCCESS, response)
+        );
+    }
+
+    @Operation(
+            summary = "비밀번호 찾기 - 아이디 확인",
+            description = "입력한 아이디가 일반 회원가입 사용자이면서 존재하는지 확인합니다."
+    )
+    @PostMapping("/find-password/check-login-id")
+    public ResponseEntity<CommonResponse<Void>> checkLoginIdForPasswordReset(
+            @Valid
+            @RequestBody
+            FindPasswordByLoginIdRequest request
+    ) {
+        checkLoginIdForPasswordResetUseCase.execute(request);
+
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.SUCCESS)
+        );
+    }
+
+    @Operation(
+            summary = "비밀번호 찾기 - 새 비밀번호 설정",
+            description = "아이디를 통해 새 비밀번호를 설정합니다. 카카오 로그인 회원은 사용할 수 없습니다."
+    )
+    @PostMapping("/find-password/reset")
+    public ResponseEntity<CommonResponse<Void>> resetPassword(
+            @Valid
+            @RequestBody
+            ResetPasswordRequest request
+    ) {
+        resetPasswordUseCase.execute(request);
+
+        return ResponseEntity.ok(
+                CommonResponse.success(ResponseMessage.MEMBER_PASSWORD_CHANGE_SUCCESS)
         );
     }
 }

--- a/src/main/java/plango/member/domain/repository/MemberRepository.java
+++ b/src/main/java/plango/member/domain/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package plango.member.domain.repository;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import plango.member.domain.entity.Member;
+import plango.member.domain.entity.LoginType;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
@@ -11,6 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickname);
+
+    Optional<Member> findByLoginIdAndLoginType(String loginId, LoginType loginType);
 
     boolean existsByLoginId(String loginId);
 

--- a/src/main/java/plango/member/domain/service/MemberPasswordResetService.java
+++ b/src/main/java/plango/member/domain/service/MemberPasswordResetService.java
@@ -1,0 +1,42 @@
+package plango.member.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.member.domain.entity.LoginType;
+import plango.member.domain.entity.Member;
+import plango.member.domain.repository.MemberRepository;
+import plango.member.exception.MemberErrorCode;
+import plango.member.exception.MemberException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberPasswordResetService {
+
+    private final MemberRepository memberRepository;
+
+    public void validateLoginId(String loginId) {
+        getNormalMemberByLoginId(loginId);
+    }
+
+    @Transactional
+    public void resetPassword(
+            String loginId,
+            String newPassword,
+            String newPasswordConfirm
+    ) {
+        if (!newPassword.equals(newPasswordConfirm)) {
+            throw new MemberException(MemberErrorCode.NEW_PASSWORD_CONFIRM_NOT_MATCH);
+        }
+
+        Member member = getNormalMemberByLoginId(loginId);
+
+        member.changePassword(newPassword);
+    }
+
+    private Member getNormalMemberByLoginId(String loginId) {
+        return memberRepository.findByLoginIdAndLoginType(loginId, LoginType.NORMAL)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #71 

## 🔎 작업 내용

- 비밀번호 찾기(아이디 확인) 기능 추가
  - `/api/auth/find-password/check-login-id` API 신규 구현
  - NORMAL 타입 회원(login_type = NORMAL)에 대해서만 아이디 존재 여부 검증
  - 카카오 로그인 회원은 login_id가 없으므로 자동적으로 조회 대상에서 제외됨

- 새 비밀번호 재설정 기능 추가
  - `/api/auth/find-password/reset` API 신규 구현
  - 새 비밀번호 / 비밀번호 확인 값 일치 여부 검증 로직 추가
  - 비밀번호 유효성 검증(6~20자, 영문 대소문자 + 숫자) 적용
  - Member 엔티티의 `changePassword()` 사용하여 비밀번호 업데이트

- MemberRepository 기능 확장
  - `findByLoginIdAndLoginType(String loginId, LoginType loginType)` 메서드 추가
  - 일반 회원가입 사용자만 비밀번호 찾기 대상으로 제한

- 서비스 / 유스케이스 계층 추가
  - `MemberPasswordResetService`
  - `CheckLoginIdForPasswordResetUseCase`
  - `ResetPasswordUseCase`
  - AuthController 내 비밀번호 찾기 관련 API 엔드포인트 2개 추가

- Swagger 문서화 반영
  - 비밀번호 찾기/재설정 API 설명 및 요청/응답 명세 추가


<br>

## 📌 참고 사항

- 카카오 로그인 사용자는 login_id가 NULL이므로 본 기능의 대상이 아님  
  → 별도의 차단 로직 없이, 조회되지 않을 경우 일반적인 “일치하는 아이디가 없습니다” 응답으로 처리
- 프론트에서는 "일반 회원가입 사용자만 비밀번호 찾기가 가능합니다" 등의 안내 메시지를 표시할 수 있음
- 회원가입 및 기존 로그인 로직과 충돌하지 않도록 기존 파일 수정 없이 신규 API 추가 방식으로 구현함

<br>

## 📌 주의해야 할 점

- 회원 데이터 구조 상 `login_id` 가 없는 카카오 회원에게는 반드시 비밀번호 찾기 UI를 노출하지 않아야 함
- 비밀번호 패턴 검증은 Bean Validation 기반이므로 프론트에서도 동일한 규칙을 맞춰 적용 필요
- 기존 로그인/회원가입 로직에 영향 없는지 QA 중점 확인 필요
- DB에 이미 존재하는 계정의 login_type 값이 NORMAL인지 반드시 확인 후 테스트 진행


## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수