### PR TITLE
Feat/#38/친구 목록, 친구 요청 목록 조회

### DIFF
--- a/src/main/java/plango/friend/application/dto/response/FriendListItemResponse.java
+++ b/src/main/java/plango/friend/application/dto/response/FriendListItemResponse.java
@@ -1,0 +1,4 @@
+package plango.friend.application.dto.response;
+
+public class FriendListItemResponse {
+}

--- a/src/main/java/plango/friend/application/dto/response/FriendListItemResponse.java
+++ b/src/main/java/plango/friend/application/dto/response/FriendListItemResponse.java
@@ -1,4 +1,9 @@
 package plango.friend.application.dto.response;
 
-public class FriendListItemResponse {
+public record FriendListItemResponse(
+        Long friendId,
+        Long memberId,
+        String nickname,
+        String profileImageUrl
+) {
 }

--- a/src/main/java/plango/friend/application/dto/response/FriendRequestListItemResponse.java
+++ b/src/main/java/plango/friend/application/dto/response/FriendRequestListItemResponse.java
@@ -1,0 +1,4 @@
+package plango.friend.application.dto.response;
+
+public class FriendRequestListItemResponse {
+}

--- a/src/main/java/plango/friend/application/dto/response/FriendRequestListItemResponse.java
+++ b/src/main/java/plango/friend/application/dto/response/FriendRequestListItemResponse.java
@@ -1,4 +1,12 @@
 package plango.friend.application.dto.response;
 
-public class FriendRequestListItemResponse {
+import java.time.LocalDateTime;
+
+public record FriendRequestListItemResponse(
+        Long friendId,
+        Long memberId,
+        String nickname,
+        String profileImageUrl,
+        LocalDateTime createdAt
+) {
 }

--- a/src/main/java/plango/friend/application/mapper/FriendMapper.java
+++ b/src/main/java/plango/friend/application/mapper/FriendMapper.java
@@ -1,8 +1,11 @@
 package plango.friend.application.mapper;
 
 import org.springframework.stereotype.Component;
+import plango.friend.application.dto.response.FriendListItemResponse;
+import plango.friend.application.dto.response.FriendRequestListItemResponse;
 import plango.friend.application.dto.response.FriendResponse;
 import plango.friend.domain.entity.Friend;
+import plango.member.domain.entity.Member;
 
 @Component
 public class FriendMapper {
@@ -14,6 +17,43 @@ public class FriendMapper {
                 friend.getReceiver().getId(),
                 friend.getReceiver().getNickname(),
                 friend.getStatus().name()
+        );
+    }
+
+    public FriendListItemResponse toFriendListItemResponse(Friend friend, Long currentMemberId) {
+        Member opponent = friend.getRequester().getId().equals(currentMemberId)
+                ? friend.getReceiver()
+                : friend.getRequester();
+
+        return new FriendListItemResponse(
+                friend.getId(),
+                opponent.getId(),
+                opponent.getNickname(),
+                opponent.getProfileImageUrl()
+        );
+    }
+
+    public FriendRequestListItemResponse toReceivedFriendRequestListItemResponse(Friend friend) {
+        Member requester = friend.getRequester();
+
+        return new FriendRequestListItemResponse(
+                friend.getId(),
+                requester.getId(),
+                requester.getNickname(),
+                requester.getProfileImageUrl(),
+                friend.getCreatedAt()
+        );
+    }
+
+    public FriendRequestListItemResponse toSentFriendRequestListItemResponse(Friend friend) {
+        Member receiver = friend.getReceiver();
+
+        return new FriendRequestListItemResponse(
+                friend.getId(),
+                receiver.getId(),
+                receiver.getNickname(),
+                receiver.getProfileImageUrl(),
+                friend.getCreatedAt()
         );
     }
 }

--- a/src/main/java/plango/friend/application/usecase/FriendListQueryUseCase.java
+++ b/src/main/java/plango/friend/application/usecase/FriendListQueryUseCase.java
@@ -1,4 +1,45 @@
 package plango.friend.application.usecase;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.friend.application.dto.response.FriendListItemResponse;
+import plango.friend.application.mapper.FriendMapper;
+import plango.friend.domain.entity.Friend;
+import plango.friend.domain.service.FriendService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberGetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FriendListQueryUseCase {
+
+    private final FriendService friendService;
+    private final FriendMapper friendMapper;
+    private final MemberGetService memberGetService;
+
+    public List<FriendListItemResponse> execute(Long memberId, String nickname) {
+        Member member = memberGetService.getById(memberId);
+        List<Friend> friends = friendService.getAcceptedFriends(member);
+
+        return friends.stream()
+                .map(friend -> friendMapper.toFriendListItemResponse(friend, memberId))
+                .filter(response -> isNicknameMatched(response.nickname(), nickname))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isNicknameMatched(String targetNickname, String keyword) {
+        if (keyword == null) {
+            return true;
+        }
+
+        if (keyword.isBlank()) {
+            return true;
+        }
+
+        return targetNickname != null && targetNickname.contains(keyword);
+    }
 }

--- a/src/main/java/plango/friend/application/usecase/FriendListQueryUseCase.java
+++ b/src/main/java/plango/friend/application/usecase/FriendListQueryUseCase.java
@@ -1,0 +1,4 @@
+package plango.friend.application.usecase;
+
+public class FriendListQueryUseCase {
+}

--- a/src/main/java/plango/friend/application/usecase/FriendReceivedRequestListQueryUseCase.java
+++ b/src/main/java/plango/friend/application/usecase/FriendReceivedRequestListQueryUseCase.java
@@ -1,4 +1,35 @@
 package plango.friend.application.usecase;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.friend.application.dto.response.FriendRequestListItemResponse;
+import plango.friend.application.mapper.FriendMapper;
+import plango.friend.domain.entity.Friend;
+import plango.friend.domain.service.FriendService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberGetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FriendReceivedRequestListQueryUseCase {
+
+    private final FriendService friendService;
+
+    private final FriendMapper friendMapper;
+
+    private final MemberGetService memberGetService;
+
+    public List<FriendRequestListItemResponse> execute(Long memberId) {
+        Member member = memberGetService.getById(memberId);
+
+        List<Friend> friends = friendService.getReceivedRequestedFriends(member);
+
+        return friends.stream()
+                .map(friendMapper::toReceivedFriendRequestListItemResponse)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/plango/friend/application/usecase/FriendReceivedRequestListQueryUseCase.java
+++ b/src/main/java/plango/friend/application/usecase/FriendReceivedRequestListQueryUseCase.java
@@ -1,0 +1,4 @@
+package plango.friend.application.usecase;
+
+public class FriendReceivedRequestListQueryUseCase {
+}

--- a/src/main/java/plango/friend/application/usecase/FriendSentRequestListQueryUseCase.java
+++ b/src/main/java/plango/friend/application/usecase/FriendSentRequestListQueryUseCase.java
@@ -1,4 +1,35 @@
 package plango.friend.application.usecase;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.friend.application.dto.response.FriendRequestListItemResponse;
+import plango.friend.application.mapper.FriendMapper;
+import plango.friend.domain.entity.Friend;
+import plango.friend.domain.service.FriendService;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberGetService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FriendSentRequestListQueryUseCase {
+
+    private final FriendService friendService;
+
+    private final FriendMapper friendMapper;
+
+    private final MemberGetService memberGetService;
+
+    public List<FriendRequestListItemResponse> execute(Long memberId) {
+        Member member = memberGetService.getById(memberId);
+
+        List<Friend> friends = friendService.getSentRequestedFriends(member);
+
+        return friends.stream()
+                .map(friendMapper::toSentFriendRequestListItemResponse)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/plango/friend/application/usecase/FriendSentRequestListQueryUseCase.java
+++ b/src/main/java/plango/friend/application/usecase/FriendSentRequestListQueryUseCase.java
@@ -1,0 +1,4 @@
+package plango.friend.application.usecase;
+
+public class FriendSentRequestListQueryUseCase {
+}

--- a/src/main/java/plango/friend/domain/repository/FriendRepository.java
+++ b/src/main/java/plango/friend/domain/repository/FriendRepository.java
@@ -1,8 +1,10 @@
 package plango.friend.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import plango.friend.domain.entity.Friend;
+import plango.friend.domain.entity.FriendStatus;
 import plango.member.domain.entity.Member;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
@@ -19,5 +21,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
     Optional<Friend> findByRequesterAndReceiver(Member requester, Member receiver);
 
     void deleteAllByRequesterOrReceiver(Member requester, Member receiver);
-}
 
+    List<Friend> findAllByRequesterAndStatus(Member requester, FriendStatus status);
+
+    List<Friend> findAllByReceiverAndStatus(Member receiver, FriendStatus status);
+}

--- a/src/main/java/plango/friend/domain/service/FriendService.java
+++ b/src/main/java/plango/friend/domain/service/FriendService.java
@@ -1,5 +1,7 @@
 package plango.friend.domain.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +49,34 @@ public class FriendService {
         friendRepository.delete(friend);
     }
 
+    public List<Friend> getAcceptedFriends(Member member) {
+        List<Friend> requestedFriends =
+                friendRepository.findAllByRequesterAndStatus(member, FriendStatus.accepted);
+
+        List<Friend> receivedFriends =
+                friendRepository.findAllByReceiverAndStatus(member, FriendStatus.accepted);
+
+        List<Friend> result = new ArrayList<>();
+
+        result.addAll(requestedFriends);
+        result.addAll(receivedFriends);
+
+        return result;
+    }
+
+    public List<Friend> getReceivedRequestedFriends(Member member) {
+        return friendRepository.findAllByReceiverAndStatus(member, FriendStatus.requested);
+    }
+
+    public List<Friend> getSentRequestedFriends(Member member) {
+        return friendRepository.findAllByRequesterAndStatus(member, FriendStatus.requested);
+    }
+
+    @Transactional
+    public void deleteAllByMember(Member member) {
+        friendRepository.deleteAllByRequesterOrReceiver(member, member);
+    }
+
     private Friend getFriendForReceiver(Long memberId, Long friendId) {
         Friend friend = friendRepository.findById(friendId)
                 .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_NOT_FOUND));
@@ -92,10 +122,5 @@ public class FriendService {
         if (exists) {
             throw new FriendException(FriendErrorCode.FRIEND_REQUEST_ALREADY_EXISTS);
         }
-    }
-
-    @Transactional
-    public void deleteAllByMember(Member member) {
-        friendRepository.deleteAllByRequesterOrReceiver(member, member);
     }
 }

--- a/src/main/java/plango/friend/presentation/FriendController.java
+++ b/src/main/java/plango/friend/presentation/FriendController.java
@@ -3,19 +3,27 @@ package plango.friend.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import plango.friend.application.dto.request.FriendRequestRequest;
+import plango.friend.application.dto.response.FriendListItemResponse;
+import plango.friend.application.dto.response.FriendRequestListItemResponse;
 import plango.friend.application.dto.response.FriendResponse;
 import plango.friend.application.usecase.FriendAcceptUseCase;
 import plango.friend.application.usecase.FriendCancelUseCase;
+import plango.friend.application.usecase.FriendListQueryUseCase;
+import plango.friend.application.usecase.FriendReceivedRequestListQueryUseCase;
 import plango.friend.application.usecase.FriendRejectUseCase;
 import plango.friend.application.usecase.FriendRequestUseCase;
+import plango.friend.application.usecase.FriendSentRequestListQueryUseCase;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
@@ -36,16 +44,74 @@ public class FriendController {
 
     private final FriendCancelUseCase friendCancelUseCase;
 
+    private final FriendListQueryUseCase friendListQueryUseCase;
+
+    private final FriendReceivedRequestListQueryUseCase friendReceivedRequestListQueryUseCase;
+
+    private final FriendSentRequestListQueryUseCase friendSentRequestListQueryUseCase;
+
     @Operation(
-            summary = "닉네임으로 친구 요청",
-            description = "앱 내 닉네임으로 친구 요청을 생성합니다."
+            summary = "친구 목록 조회",
+            description = "내 친구 목록을 조회합니다. 닉네임 검색어를 전달하면 해당 닉네임을 포함하는 친구만 조회합니다."
     )
-    @PostMapping
+    @GetMapping
+    public CommonResponse<List<FriendListItemResponse>> getFriends(
+            @RequestHeader("X-Member-Id") Long memberId,
+            @RequestParam(required = false) String nickname
+    ) {
+        List<FriendListItemResponse> responses = friendListQueryUseCase.execute(memberId, nickname);
+
+        return CommonResponse.success(
+                ResponseMessage.FRIEND_LIST_GET_SUCCESS,
+                responses
+        );
+    }
+
+    @Operation(
+            summary = "받은 친구 요청 목록 조회",
+            description = "현재 사용자에게 도착한 친구 요청 목록을 조회합니다."
+    )
+    @GetMapping("/requests/received")
+    public CommonResponse<List<FriendRequestListItemResponse>> getReceivedFriendRequests(
+            @RequestHeader("X-Member-Id") Long memberId
+    ) {
+        List<FriendRequestListItemResponse> responses =
+                friendReceivedRequestListQueryUseCase.execute(memberId);
+
+        return CommonResponse.success(
+                ResponseMessage.FRIEND_REQUEST_RECEIVED_LIST_GET_SUCCESS,
+                responses
+        );
+    }
+
+    @Operation(
+            summary = "보낸 친구 요청 목록 조회",
+            description = "현재 사용자가 보낸 친구 요청 목록을 조회합니다."
+    )
+    @GetMapping("/requests/sent")
+    public CommonResponse<List<FriendRequestListItemResponse>> getSentFriendRequests(
+            @RequestHeader("X-Member-Id") Long memberId
+    ) {
+        List<FriendRequestListItemResponse> responses =
+                friendSentRequestListQueryUseCase.execute(memberId);
+
+        return CommonResponse.success(
+                ResponseMessage.FRIEND_REQUEST_SENT_LIST_GET_SUCCESS,
+                responses
+        );
+    }
+
+    @Operation(
+            summary = "친구 요청",
+            description = "닉네임으로 친구 요청을 보냅니다."
+    )
+    @PostMapping("/request")
     public CommonResponse<FriendResponse> requestFriend(
             @RequestHeader("X-Member-Id") Long memberId,
-            @RequestBody @Valid FriendRequestRequest request
+            @Valid @RequestBody FriendRequestRequest request
     ) {
         FriendResponse response = friendRequestUseCase.execute(memberId, request);
+
         return CommonResponse.success(
                 ResponseMessage.FRIEND_REQUEST_CREATE_SUCCESS,
                 response
@@ -62,6 +128,7 @@ public class FriendController {
             @PathVariable Long friendId
     ) {
         FriendResponse response = friendAcceptUseCase.execute(memberId, friendId);
+
         return CommonResponse.success(
                 ResponseMessage.FRIEND_ACCEPT_SUCCESS,
                 response
@@ -78,6 +145,7 @@ public class FriendController {
             @PathVariable Long friendId
     ) {
         friendRejectUseCase.execute(memberId, friendId);
+
         return CommonResponse.success(
                 ResponseMessage.FRIEND_REJECT_SUCCESS
         );
@@ -93,6 +161,7 @@ public class FriendController {
             @PathVariable Long friendId
     ) {
         friendCancelUseCase.execute(memberId, friendId);
+
         return CommonResponse.success(
                 ResponseMessage.FRIEND_CANCEL_SUCCESS
         );

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -20,7 +20,7 @@ public enum ResponseMessage {
     // ===== 프로필 =====
     MEMBER_PROFILE_GET_SUCCESS(0, "프로필 조회 성공"),
     MEMBER_PROFILE_UPDATE_SUCCESS(0, "프로필 수정 성공"),
-    MEMBER_PASSWORD_CHANGE_SUCCESS(0,"비밀번호 변경에 성공했습니다."),
+    MEMBER_PASSWORD_CHANGE_SUCCESS(0, "비밀번호 변경에 성공했습니다."),
 
     // ===== 여행방 장소 (RoomPlace) =====
     ROOM_PLACE_LIST_SUCCESS(0, "위시리스트 장소 조회 성공"),
@@ -42,8 +42,8 @@ public enum ResponseMessage {
     ROOM_DETAIL_GET_SUCCESS(0, "여행방 상세 조회 성공"),
 
     // ===== 알림 =====
-    NOTIFICATION_SETTING_READ_SUCCESS(0,"알림 설정 조회 성공"),
-    NOTIFICATION_SETTING_UPDATE_SUCCESS(0,"알림 설정 변경 성공"),
+    NOTIFICATION_SETTING_READ_SUCCESS(0, "알림 설정 조회 성공"),
+    NOTIFICATION_SETTING_UPDATE_SUCCESS(0, "알림 설정 변경 성공"),
 
     // ===== 친구 요청 / 관리 =====
     FRIEND_REQUEST_CREATE_SUCCESS(0, "친구 요청 생성 성공"),
@@ -53,6 +53,9 @@ public enum ResponseMessage {
     FRIEND_ACCEPT_SUCCESS(0, "친구 요청 수락 성공"),
     FRIEND_REJECT_SUCCESS(0, "친구 요청 거절 성공"),
     FRIEND_CANCEL_SUCCESS(0, "친구 요청 취소 성공"),
+    FRIEND_LIST_GET_SUCCESS(0, "친구 목록 조회 성공"),
+    FRIEND_REQUEST_RECEIVED_LIST_GET_SUCCESS(0, "받은 친구 요청 목록 조회 성공"),
+    FRIEND_REQUEST_SENT_LIST_GET_SUCCESS(0, "보낸 친구 요청 목록 조회 성공"),
 
     // ===== 채팅 =====
     CHAT_MESSAGE_SEND_SUCCESS(0, "채팅 메시지 전송 성공"),


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #77 

🔎 작업 내용
- 친구 요청 목록 조회 기능 구현
  - 받은 친구 요청 목록 조회 API 추가 → GET /api/friends/requests/received
  - 보낸 친구 요청 목록 조회 API 추가 → GET /api/friends/requests/sent
- 요청 목록 조회를 위한 UseCase / DTO / Mapper 로직 추가
- FriendService에 요청 상태(FriendStatus.requested) 기반 조회 메서드 추가
- Controller에 Swagger 문서(summary/description) 적용
- ResponseMessage에
  - FRIEND_REQUEST_RECEIVED_LIST_GET_SUCCESS
  - FRIEND_REQUEST_SENT_LIST_GET_SUCCESS 추가
- 전체 플로우를 기존 구조(application/usecase → domain/service → presentation)대로 맞춰 구성

<br>

📌 참고 사항
- 중복 요청 여부, 본인 요청 필터링, 수락된 친구와의 구분 등 기존 FriendService 로직과 충돌 없도록 설계
- 닉네임 기반 친구 검색/추가, 친구 수락/거절/취소 기능과 자연스럽게 연동되는 구조
- ResponseMessage 규칙에 맞춰 응답 메시지 통일
- 프론트에서 받은/보낸 요청을 각각 모달 형태로 보여줄 수 있도록 DTO 필드 구성 (friendId, nickname, profileImageUrl, createdAt 등)

<br>

📌 주의해야 할 점
- 요청 상태(FriendStatus.requested) 외의 상태(ex: accepted)는 조회되지 않도록 보장
- 받은 요청/보낸 요청이 동시에 존재할 때 API 응답 혼동 없도록 UseCase 분리
- API 사용 시 반드시 헤더 X-Member-Id 필요
<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수