### PR TITLE
Feat/#39/친구 삭제

### DIFF
--- a/src/main/java/plango/friend/application/usecase/FriendDeleteUseCase.java
+++ b/src/main/java/plango/friend/application/usecase/FriendDeleteUseCase.java
@@ -1,0 +1,18 @@
+package plango.friend.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.friend.domain.service.FriendService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FriendDeleteUseCase {
+
+    private final FriendService friendService;
+
+    public void execute(Long memberId, Long friendId) {
+        friendService.deleteFriend(memberId, friendId);
+    }
+}

--- a/src/main/java/plango/friend/domain/service/FriendService.java
+++ b/src/main/java/plango/friend/domain/service/FriendService.java
@@ -73,6 +73,30 @@ public class FriendService {
     }
 
     @Transactional
+    public void deleteFriend(Long memberId, Long friendId) {
+        Friend friend = friendRepository.findById(friendId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_NOT_FOUND));
+
+        boolean isRequester = friend.getRequester()
+                .getId()
+                .equals(memberId);
+
+        boolean isReceiver = friend.getReceiver()
+                .getId()
+                .equals(memberId);
+
+        if (!isRequester && !isReceiver) {
+            throw new FriendException(FriendErrorCode.FRIEND_NOT_FOUND);
+        }
+
+        if (friend.getStatus() != FriendStatus.accepted) {
+            throw new FriendException(FriendErrorCode.INVALID_FRIEND_STATUS);
+        }
+
+        friendRepository.delete(friend);
+    }
+
+    @Transactional
     public void deleteAllByMember(Member member) {
         friendRepository.deleteAllByRequesterOrReceiver(member, member);
     }

--- a/src/main/java/plango/friend/presentation/FriendController.java
+++ b/src/main/java/plango/friend/presentation/FriendController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +20,7 @@ import plango.friend.application.dto.response.FriendRequestListItemResponse;
 import plango.friend.application.dto.response.FriendResponse;
 import plango.friend.application.usecase.FriendAcceptUseCase;
 import plango.friend.application.usecase.FriendCancelUseCase;
+import plango.friend.application.usecase.FriendDeleteUseCase;
 import plango.friend.application.usecase.FriendListQueryUseCase;
 import plango.friend.application.usecase.FriendReceivedRequestListQueryUseCase;
 import plango.friend.application.usecase.FriendRejectUseCase;
@@ -49,6 +51,8 @@ public class FriendController {
     private final FriendReceivedRequestListQueryUseCase friendReceivedRequestListQueryUseCase;
 
     private final FriendSentRequestListQueryUseCase friendSentRequestListQueryUseCase;
+
+    private final FriendDeleteUseCase friendDeleteUseCase;
 
     @Operation(
             summary = "친구 목록 조회",
@@ -164,6 +168,22 @@ public class FriendController {
 
         return CommonResponse.success(
                 ResponseMessage.FRIEND_CANCEL_SUCCESS
+        );
+    }
+
+    @Operation(
+            summary = "친구 삭제",
+            description = "친구 목록에서 선택한 친구를 삭제합니다."
+    )
+    @DeleteMapping("/{friendId}")
+    public CommonResponse<Void> deleteFriend(
+            @RequestHeader("X-Member-Id") Long memberId,
+            @PathVariable Long friendId
+    ) {
+        friendDeleteUseCase.execute(memberId, friendId);
+
+        return CommonResponse.success(
+                ResponseMessage.FRIEND_DELETE_SUCCESS
         );
     }
 }

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -56,6 +56,7 @@ public enum ResponseMessage {
     FRIEND_LIST_GET_SUCCESS(0, "친구 목록 조회 성공"),
     FRIEND_REQUEST_RECEIVED_LIST_GET_SUCCESS(0, "받은 친구 요청 목록 조회 성공"),
     FRIEND_REQUEST_SENT_LIST_GET_SUCCESS(0, "보낸 친구 요청 목록 조회 성공"),
+    FRIEND_DELETE_SUCCESS(0, "친구 삭제 성공"),
 
     // ===== 채팅 =====
     CHAT_MESSAGE_SEND_SUCCESS(0, "채팅 메시지 전송 성공"),


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #79 

## 🔎 작업 내용

- 친구 삭제 기능 구현
  - DELETE /api/friends/{friendId} API 추가
  - 친구 관계(Friend 엔티티) 삭제 로직 추가 (수락된 친구 관계만 삭제 가능)
- FriendDeleteUseCase 신규 생성
- FriendService에 친구 삭제 비즈니스 로직 추가
- ResponseMessage에 FRIEND_DELETE_SUCCESS 추가
- Controller에 Swagger 문서 적용 및 기존 친구 기능들과 자연스럽게 연동되도록 구조 유지
- 친구 목록 페이지와 연동 테스트 완료 (삭제 후 목록 정상 갱신 확인)

<br>

📌 참고 사항
- 삭제 가능한 조건은 반드시 현재 로그인한 사용자가 해당 Friend 관계의 requester 또는 receiver인 경우로 제한
- 삭제 동작은 accepted(친구) 상태에만 허용
- 친구 요청 상태(requested)는 삭제 대상이 아님 (취소/거절 API 별도 존재)
- 전체 코드 구조는 기존 컨벤션(Controller → UseCase → Service → Repository)에 맞춰 작성
- 응답 형식은 CommonResponse + ResponseMessage.FRIEND_DELETE_SUCCESS 통일 처리

<br>
📌 주의해야 할 점
- 삭제 후 클라이언트에서 즉시 친구 목록 재호출 필요
- 존재하지 않는 friendId 삭제 시 FriendException 처리됨
- 본인이 속하지 않은 친구 관계 삭제 시도 시 FRIEND_NOT_FOUND 반환
- 여행방/채팅 기능과는 무관하며, 삭제 이후에도 기존 여행방 멤버십은 변하지 않음

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수