### PR TITLE
Feat/#40/닉네임 기반 사용자 검색

### DIFF
--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -17,6 +17,9 @@ public enum ResponseMessage {
     MEMBER_LOGIN_ID_CHECK_SUCCESS(0, "아이디 중복 확인 성공"),
     MEMBER_EMAIL_CHECK_SUCCESS(0, "이메일 중복 확인 성공"),
 
+    // ===== 멤버 검색 =====
+    MEMBER_SEARCH_BY_NICKNAME_SUCCESS(0, "사용자 검색 성공"),
+
     // ===== 프로필 =====
     MEMBER_PROFILE_GET_SUCCESS(0, "프로필 조회 성공"),
     MEMBER_PROFILE_UPDATE_SUCCESS(0, "프로필 수정 성공"),

--- a/src/main/java/plango/member/application/dto/response/MemberSearchResponse.java
+++ b/src/main/java/plango/member/application/dto/response/MemberSearchResponse.java
@@ -1,0 +1,8 @@
+package plango.member.application.dto.response;
+
+public record MemberSearchResponse(
+        Long memberId,
+        String nickname,
+        String profileImageUrl
+) {
+}

--- a/src/main/java/plango/member/application/mapper/MemberSearchMapper.java
+++ b/src/main/java/plango/member/application/mapper/MemberSearchMapper.java
@@ -1,0 +1,17 @@
+package plango.member.application.mapper;
+
+import org.springframework.stereotype.Component;
+import plango.member.application.dto.response.MemberSearchResponse;
+import plango.member.domain.entity.Member;
+
+@Component
+public class MemberSearchMapper {
+
+    public MemberSearchResponse toSearchResponse(Member member) {
+        return new MemberSearchResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/plango/member/application/usecase/SearchMemberByNicknameUseCase.java
+++ b/src/main/java/plango/member/application/usecase/SearchMemberByNicknameUseCase.java
@@ -1,0 +1,21 @@
+package plango.member.application.usecase;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import plango.member.application.dto.response.MemberSearchResponse;
+import plango.member.application.mapper.MemberSearchMapper;
+import plango.member.domain.entity.Member;
+import plango.member.domain.service.MemberQueryService;
+
+@Service
+@RequiredArgsConstructor
+public class SearchMemberByNicknameUseCase {
+
+    private final MemberQueryService memberQueryService;
+    private final MemberSearchMapper memberSearchMapper;
+
+    public MemberSearchResponse execute(String nickname) {
+        Member member = memberQueryService.getByNickname(nickname);
+        return memberSearchMapper.toSearchResponse(member);
+    }
+}

--- a/src/main/java/plango/member/domain/service/MemberQueryService.java
+++ b/src/main/java/plango/member/domain/service/MemberQueryService.java
@@ -1,0 +1,27 @@
+package plango.member.domain.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import plango.member.domain.entity.Member;
+import plango.member.domain.repository.MemberRepository;
+import plango.member.exception.MemberErrorCode;
+import plango.member.exception.MemberException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberQueryService {
+
+    private final MemberRepository memberRepository;
+
+    public Optional<Member> findByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname);
+    }
+
+    public Member getByNickname(String nickname) {
+        return memberRepository.findByNickname(nickname)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/plango/member/presentation/MemberController.java
+++ b/src/main/java/plango/member/presentation/MemberController.java
@@ -1,56 +1,75 @@
 package plango.member.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
-import plango.member.application.dto.request.MemberProfileUpdateRequest;
 import plango.member.application.dto.request.ChangePasswordRequest;
+import plango.member.application.dto.request.MemberProfileUpdateRequest;
 import plango.member.application.dto.response.MemberProfileResponse;
-import plango.member.application.usecase.GetMyProfileUseCase;
-import plango.member.application.usecase.UpdateMyProfileUseCase;
+import plango.member.application.dto.response.MemberSearchResponse;
 import plango.member.application.usecase.ChangePasswordUseCase;
+import plango.member.application.usecase.GetMyProfileUseCase;
 import plango.member.application.usecase.MemberWithdrawUseCase;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
+import plango.member.application.usecase.SearchMemberByNicknameUseCase;
+import plango.member.application.usecase.UpdateMyProfileUseCase;
 
-@Tag(name = "멤버 프로필", description = "회원 프로필 조회 및 수정 API")
+@Tag(
+        name = "멤버 프로필",
+        description = "회원 프로필 조회 및 수정 API"
+)
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
 public class MemberController {
 
     private final GetMyProfileUseCase getMyProfileUseCase;
+
     private final UpdateMyProfileUseCase updateMyProfileUseCase;
+
     private final ChangePasswordUseCase changePasswordUseCase;
+
     private final MemberWithdrawUseCase memberWithdrawUseCase;
 
-    @Operation(summary = "프로필 조회", description = "memberId를 기준으로 프로필 정보를 조회합니다.")
+    private final SearchMemberByNicknameUseCase searchMemberByNicknameUseCase;
+
+    @Operation(
+            summary = "프로필 조회",
+            description = "memberId를 기준으로 프로필 정보를 조회합니다."
+    )
     @GetMapping("/{memberId}")
     public CommonResponse<MemberProfileResponse> getProfile(
             @PathVariable Long memberId
     ) {
         MemberProfileResponse response = getMyProfileUseCase.execute(memberId);
+
         return CommonResponse.success(
                 ResponseMessage.MEMBER_PROFILE_GET_SUCCESS,
                 response
         );
     }
 
-    @Operation(summary = "프로필 수정", description = "nickname, profileImageUrl 값을 수정합니다.")
+    @Operation(
+            summary = "프로필 수정",
+            description = "nickname, profileImageUrl 값을 수정합니다."
+    )
     @PatchMapping("/{memberId}")
     public CommonResponse<Void> updateProfile(
             @PathVariable Long memberId,
             @RequestBody @Valid MemberProfileUpdateRequest request
     ) {
         updateMyProfileUseCase.execute(memberId, request);
+
         return CommonResponse.success(
                 ResponseMessage.MEMBER_PROFILE_UPDATE_SUCCESS
         );
@@ -65,20 +84,41 @@ public class MemberController {
             @PathVariable Long memberId
     ) {
         memberWithdrawUseCase.execute(memberId);
+
         return CommonResponse.success(
                 ResponseMessage.MEMBER_WITHDRAW_SUCCESS
         );
     }
 
-    @Operation(summary = "비밀번호 변경", description = "현재 비밀번호를 검증하고 새 비밀번호로 변경합니다.")
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "현재 비밀번호를 검증하고 새 비밀번호로 변경합니다."
+    )
     @PatchMapping("/{memberId}/password")
     public CommonResponse<Void> changePassword(
             @PathVariable Long memberId,
             @RequestBody @Valid ChangePasswordRequest request
     ) {
         changePasswordUseCase.execute(memberId, request);
+
         return CommonResponse.success(
                 ResponseMessage.MEMBER_PASSWORD_CHANGE_SUCCESS
+        );
+    }
+
+    @Operation(
+            summary = "사용자 닉네임 검색",
+            description = "닉네임을 기준으로 사용자 정보를 조회합니다. 친구 추가 전 검색용 API입니다."
+    )
+    @GetMapping("/search")
+    public CommonResponse<MemberSearchResponse> searchMemberByNickname(
+            @RequestParam String nickname
+    ) {
+        MemberSearchResponse response = searchMemberByNicknameUseCase.execute(nickname);
+
+        return CommonResponse.success(
+                ResponseMessage.MEMBER_SEARCH_BY_NICKNAME_SUCCESS,
+                response
         );
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #81 

## 🔎 작업 내용

- 닉네임 기반 사용자 검색 기능 구현
  - GET /api/members/search API 추가
  - 닉네임으로 DB에서 사용자 정보를 조회하여 친구 요청 전에 대상 회원을 검색할 수 있도록 기능 제공
- MemberSearchResponse, MemberSearchMapper, MemberQueryService, SearchMemberByNicknameUseCase 추가
- ResponseMessage에 MEMBER_SEARCH_BY_NICKNAME_SUCCESS 상수 추가
- MemberController에 검색 API 및 Swagger 문서 추가
- 프론트 친구 추가 화면과 연동 테스트 완료

<br>


## 📌 참고 사항

- 친구 요청 API와 분리된 검색 전용 API로, 친구 추가 전에 검색을 수행하는 형태로 사용
- 닉네임이 존재하지 않을 경우 MEMBER_NOT_FOUND 예외 발생 → 글로벌 예외 핸들러에서 404 처리
- 기존 프로필 API 및 멤버 관련 기능들과 충돌 없이 동작하도록 독립적인 UseCase로 설계
- 검색 결과는 닉네임, memberId, profileImageUrl만 제공 (불필요한 개인정보 노출 방지)

<br>

## 📌 주의해야 할 점

- 닉네임은 정확히 일치하는 값만 검색됨 (부분 검색 아님)
- 닉네임이 없는 사용자(카카오 로그인 직후 닉네임 미설정)는 검색이 불가능
- 프론트에서 검색 후 “친구 요청하기”를 누르면 별도로 POST /api/friends/request를 호출해야 함
- 닉네임 필드는 유니크 값이므로 검색 결과는 항상 0개 또는 1개만 반환됨
<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수