### PR TITLE
Fix/#45/jwt 기반 인증 토큰 설계 및 재발급

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.5'          // 필요에 맞게 조정
+	id 'org.springframework.boot' version '3.2.5'
 	id 'io.spring.dependency-management' version '1.1.4'
 }
 
@@ -9,7 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)        // JDK 17 권장
+		languageVersion = JavaLanguageVersion.of(17)
 	}
 }
 
@@ -19,35 +19,22 @@ repositories {
 
 dependencies {
 
-	// 웹 서버 (Tomcat 내장)
+	// Spring Web / JPA / Validation
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-
-	// JPA (Hibernate)
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
-	// MySQL 드라이버
-	runtimeOnly 'com.mysql:mysql-connector-j'
-
-	// 테스트
+	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
-	// Spring
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation' // @Valid / Bean Validation
 
 	// Swagger (springdoc)
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-
-	//Flyway
+	// Flyway
 	implementation 'org.flywaydb:flyway-core'
 	runtimeOnly 'org.flywaydb:flyway-mysql'
 
-	// DB Driver (MySQL 사용 시)
+	// DB Driver (MySQL)
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// AWS SDK v2 BOM
@@ -55,11 +42,24 @@ dependencies {
 	// S3 클라이언트
 	implementation "software.amazon.awssdk:s3"
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
+	// Security (비밀번호 인코딩 + JWT 필터)
 	implementation 'org.springframework.security:spring-security-crypto'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// JWT (JJWT)
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// WebSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// Test
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/plango/auth/application/dto/request/TokenReissueRequest.java
+++ b/src/main/java/plango/auth/application/dto/request/TokenReissueRequest.java
@@ -1,0 +1,9 @@
+package plango.auth.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenReissueRequest(
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/plango/auth/application/exception/AuthErrorCode.java
+++ b/src/main/java/plango/auth/application/exception/AuthErrorCode.java
@@ -1,0 +1,22 @@
+package plango.auth.application.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode {
+
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 액세스 토큰입니다."),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 액세스 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    public int getStatusCode() {
+        return status.value();
+    }
+}

--- a/src/main/java/plango/auth/application/exception/AuthException.java
+++ b/src/main/java/plango/auth/application/exception/AuthException.java
@@ -1,0 +1,15 @@
+package plango.auth.application.exception;
+
+import lombok.Getter;
+import plango.global.common.exception.BusinessException;
+
+@Getter
+public class AuthException extends BusinessException {
+
+    private final AuthErrorCode errorCode;
+
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode.getStatusCode(), errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/plango/auth/application/mapper/KakaoAuthMapper.java
+++ b/src/main/java/plango/auth/application/mapper/KakaoAuthMapper.java
@@ -18,12 +18,6 @@ public class KakaoAuthMapper {
         return "KAKAO_TMP_" + uuid.substring(0, 12);
     }
 
-    private static String createRandomToken() {
-        return UUID.randomUUID()
-                .toString()
-                .replace("-", "");
-    }
-
     public static Member toMember(KakaoUserInfoResponse kakaoUserInfo) {
         String email = kakaoUserInfo.getEmail();
         String profileImageUrl = kakaoUserInfo.getProfileImageUrl();
@@ -38,16 +32,15 @@ public class KakaoAuthMapper {
 
     public static KakaoLoginResponse toKakaoLoginResponse(
             Member member,
-            boolean newMember
+            boolean newMember,
+            String accessToken,
+            String refreshToken
     ) {
         String nickname = null;
 
         if (!newMember) {
             nickname = member.getNickname();
         }
-
-        String accessToken = createRandomToken();
-        String refreshToken = createRandomToken();
 
         return KakaoLoginResponse.builder()
                 .memberId(member.getId())

--- a/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/KakaoLoginUseCase.java
@@ -8,6 +8,7 @@ import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.dto.response.KakaoUserInfoResponse;
 import plango.auth.application.mapper.KakaoAuthMapper;
 import plango.auth.domain.entity.SocialAccount;
+import plango.auth.domain.service.JwtTokenProvider;
 import plango.auth.domain.service.KakaoAuthService;
 import plango.auth.domain.service.SocialAccountService;
 import plango.member.domain.entity.Member;
@@ -21,10 +22,9 @@ public class KakaoLoginUseCase {
     private static final String KAKAO_PROVIDER = "KAKAO";
 
     private final KakaoAuthService kakaoAuthService;
-
-    private final MemberService memberService;
-
     private final SocialAccountService socialAccountService;
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Transactional
     public KakaoLoginResponse execute(KakaoLoginRequest request) {
@@ -32,7 +32,6 @@ public class KakaoLoginUseCase {
                 kakaoAuthService.getUserInfoByAuthorizationCode(request.authorizationCode());
 
         Long kakaoId = kakaoUserInfo.id();
-
         String email = kakaoUserInfo.getEmail();
 
         SocialAccount socialAccount =
@@ -43,7 +42,6 @@ public class KakaoLoginUseCase {
                         .orElse(null);
 
         Member member;
-
         boolean isNewMember;
 
         if (socialAccount == null) {
@@ -68,10 +66,17 @@ public class KakaoLoginUseCase {
             isNewMember = true;
         } else {
             member = socialAccount.getMember();
-
             isNewMember = false;
         }
 
-        return KakaoAuthMapper.toKakaoLoginResponse(member, isNewMember);
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
+        return KakaoAuthMapper.toKakaoLoginResponse(
+                member,
+                isNewMember,
+                accessToken,
+                refreshToken
+        );
     }
 }

--- a/src/main/java/plango/auth/application/usecase/TokenReissueUseCase.java
+++ b/src/main/java/plango/auth/application/usecase/TokenReissueUseCase.java
@@ -3,7 +3,7 @@ package plango.auth.application.usecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import plango.auth.application.dto.request.MemberLoginRequest;
+import plango.auth.application.dto.request.TokenReissueRequest;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.mapper.KakaoAuthMapper;
 import plango.auth.domain.service.JwtTokenProvider;
@@ -13,25 +13,26 @@ import plango.member.domain.service.MemberService;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class MemberLoginUseCase {
+public class TokenReissueUseCase {
 
-    private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
 
-    public KakaoLoginResponse execute(MemberLoginRequest request) {
-        Member member = memberService.loginByLoginId(
-                request.loginId(),
-                request.password()
-        );
+    public KakaoLoginResponse execute(TokenReissueRequest request) {
+        String refreshToken = request.refreshToken();
 
-        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
-        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        Long memberId = jwtTokenProvider.getMemberIdFromRefreshToken(refreshToken);
+
+        Member member = memberService.getById(memberId);
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getId());
 
         return KakaoAuthMapper.toKakaoLoginResponse(
                 member,
                 false,
-                accessToken,
-                refreshToken
+                newAccessToken,
+                newRefreshToken
         );
     }
 }

--- a/src/main/java/plango/auth/domain/service/JwtTokenProvider.java
+++ b/src/main/java/plango/auth/domain/service/JwtTokenProvider.java
@@ -1,0 +1,116 @@
+package plango.auth.domain.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import plango.auth.application.exception.AuthErrorCode;
+import plango.auth.application.exception.AuthException;
+
+@Slf4j
+@Service
+public class JwtTokenProvider {
+
+    private static final String CLAIM_TYPE = "type";
+    private static final String TYPE_ACCESS = "ACCESS";
+    private static final String TYPE_REFRESH = "REFRESH";
+
+    private final Key secretKey;
+    private final long accessTokenValidityInMillis;
+    private final long refreshTokenValidityInMillis;
+
+    public JwtTokenProvider(
+            @Value("${security.jwt.secret-key}") String secretKey,
+            @Value("${security.jwt.access-token-validity-in-seconds}") long accessTokenValidityInSeconds,
+            @Value("${security.jwt.refresh-token-validity-in-seconds}") long refreshTokenValidityInSeconds
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidityInMillis = accessTokenValidityInSeconds * 1000L;
+        this.refreshTokenValidityInMillis = refreshTokenValidityInSeconds * 1000L;
+    }
+
+    public String createAccessToken(Long memberId) {
+        return createToken(memberId, TYPE_ACCESS, accessTokenValidityInMillis);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        return createToken(memberId, TYPE_REFRESH, refreshTokenValidityInMillis);
+    }
+
+    private String createToken(
+            Long memberId,
+            String type,
+            long validityInMillis
+    ) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + validityInMillis);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .claim(CLAIM_TYPE, type)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long getMemberIdFromAccessToken(String token) {
+        Claims claims = parseAccessTokenClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public Long getMemberIdFromRefreshToken(String token) {
+        Claims claims = parseRefreshTokenClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
+
+    private Claims parseAccessTokenClaims(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            String type = claims.get(CLAIM_TYPE, String.class);
+
+            if (!TYPE_ACCESS.equals(type)) {
+                throw new AuthException(AuthErrorCode.INVALID_ACCESS_TOKEN);
+            }
+
+            return claims;
+        } catch (ExpiredJwtException exception) {
+            throw new AuthException(AuthErrorCode.EXPIRED_ACCESS_TOKEN);
+        } catch (JwtException | IllegalArgumentException exception) {
+            throw new AuthException(AuthErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    private Claims parseRefreshTokenClaims(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            String type = claims.get(CLAIM_TYPE, String.class);
+
+            if (!TYPE_REFRESH.equals(type)) {
+                throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            }
+
+            return claims;
+        } catch (ExpiredJwtException exception) {
+            throw new AuthException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
+        } catch (JwtException | IllegalArgumentException exception) {
+            throw new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/plango/auth/presentation/AuthController.java
+++ b/src/main/java/plango/auth/presentation/AuthController.java
@@ -22,6 +22,7 @@ import plango.auth.application.dto.request.FindLoginIdRequest;
 import plango.auth.application.dto.request.VerifyLoginIdCodeRequest;
 import plango.auth.application.dto.request.FindPasswordByLoginIdRequest;
 import plango.auth.application.dto.request.ResetPasswordRequest;
+import plango.auth.application.dto.request.TokenReissueRequest;
 import plango.auth.application.dto.response.DuplicateCheckResponse;
 import plango.auth.application.dto.response.KakaoLoginResponse;
 import plango.auth.application.dto.response.MemberSignUpResponse;
@@ -40,10 +41,11 @@ import plango.auth.application.usecase.SendLoginIdVerificationCodeUseCase;
 import plango.auth.application.usecase.VerifyLoginIdCodeUseCase;
 import plango.auth.application.usecase.CheckLoginIdForPasswordResetUseCase;
 import plango.auth.application.usecase.ResetPasswordUseCase;
+import plango.auth.application.usecase.TokenReissueUseCase;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 
-@Tag(name = "Auth", description = "인증 관련 API")
+@Tag(name = "Auth API", description = "인증 / 인가 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
@@ -61,6 +63,7 @@ public class AuthController {
     private final VerifyLoginIdCodeUseCase verifyLoginIdCodeUseCase;
     private final CheckLoginIdForPasswordResetUseCase checkLoginIdForPasswordResetUseCase;
     private final ResetPasswordUseCase resetPasswordUseCase;
+    private final TokenReissueUseCase tokenReissueUseCase;
 
     @Operation(summary = "일반 회원가입", description = "이름, 닉네임, 아이디, 비밀번호, 이메일로 회원가입합니다.")
     @PostMapping("/signup")
@@ -246,6 +249,26 @@ public class AuthController {
 
         return ResponseEntity.ok(
                 CommonResponse.success(ResponseMessage.MEMBER_PASSWORD_CHANGE_SUCCESS)
+        );
+    }
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "리프레시 토큰을 사용해 액세스 토큰과 리프레시 토큰을 재발급합니다."
+    )
+    @PostMapping("/token/reissue")
+    public ResponseEntity<CommonResponse<KakaoLoginResponse>> reissueToken(
+            @Valid
+            @RequestBody
+            TokenReissueRequest request
+    ) {
+        KakaoLoginResponse response = tokenReissueUseCase.execute(request);
+
+        return ResponseEntity.ok(
+                CommonResponse.success(
+                        ResponseMessage.AUTH_TOKEN_REISSUE_SUCCESS,
+                        response
+                )
         );
     }
 }

--- a/src/main/java/plango/friend/presentation/FriendController.java
+++ b/src/main/java/plango/friend/presentation/FriendController.java
@@ -5,12 +5,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -60,7 +60,7 @@ public class FriendController {
     )
     @GetMapping
     public CommonResponse<List<FriendListItemResponse>> getFriends(
-            @RequestHeader("X-Member-Id") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @RequestParam(required = false) String nickname
     ) {
         List<FriendListItemResponse> responses =
@@ -78,7 +78,7 @@ public class FriendController {
     )
     @GetMapping("/requests/received")
     public CommonResponse<List<FriendRequestListItemResponse>> getReceivedFriendRequests(
-            @RequestHeader("X-Member-Id") Long memberId
+            @AuthenticationPrincipal Long memberId
     ) {
         List<FriendRequestListItemResponse> responses =
                 friendReceivedRequestListQueryUseCase.execute(memberId);
@@ -95,7 +95,7 @@ public class FriendController {
     )
     @GetMapping("/requests/sent")
     public CommonResponse<List<FriendRequestListItemResponse>> getSentFriendRequests(
-            @RequestHeader("X-Member-Id") Long memberId
+            @AuthenticationPrincipal Long memberId
     ) {
         List<FriendRequestListItemResponse> responses =
                 friendSentRequestListQueryUseCase.execute(memberId);
@@ -112,7 +112,7 @@ public class FriendController {
     )
     @PostMapping
     public CommonResponse<FriendResponse> requestFriend(
-            @RequestHeader("X-Member-Id") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody FriendRequestRequest request
     ) {
         FriendResponse response = friendRequestUseCase.execute(memberId, request);
@@ -129,7 +129,7 @@ public class FriendController {
     )
     @PostMapping("/{friendId}/accept")
     public CommonResponse<FriendResponse> acceptFriend(
-            @RequestHeader("X-Member-Id") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @PathVariable Long friendId
     ) {
         FriendResponse response = friendAcceptUseCase.execute(memberId, friendId);
@@ -146,7 +146,7 @@ public class FriendController {
     )
     @PostMapping("/{friendId}/reject")
     public CommonResponse<Void> rejectFriend(
-            @RequestHeader("X-Member-Id") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @PathVariable Long friendId
     ) {
         friendRejectUseCase.execute(memberId, friendId);
@@ -162,7 +162,7 @@ public class FriendController {
     )
     @PostMapping("/{friendId}/cancel")
     public CommonResponse<Void> cancelFriend(
-            @RequestHeader("X-Member-Id") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @PathVariable Long friendId
     ) {
         friendCancelUseCase.execute(memberId, friendId);
@@ -178,7 +178,7 @@ public class FriendController {
     )
     @DeleteMapping("/{friendId}")
     public CommonResponse<Void> deleteFriend(
-            @RequestHeader("X-Member-Id") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @PathVariable Long friendId
     ) {
         friendDeleteUseCase.execute(memberId, friendId);

--- a/src/main/java/plango/global/common/response/ResponseMessage.java
+++ b/src/main/java/plango/global/common/response/ResponseMessage.java
@@ -64,7 +64,9 @@ public enum ResponseMessage {
     // ===== 채팅 =====
     CHAT_MESSAGE_SEND_SUCCESS(0, "채팅 메시지 전송 성공"),
     CHAT_MESSAGE_LIST_GET_SUCCESS(0, "채팅 메시지 목록 조회 성공"),
-    CHAT_MESSAGE_HISTORY_BEFORE_GET_SUCCESS(0, "채팅 이전 메시지 목록 조회 성공");
+    CHAT_MESSAGE_HISTORY_BEFORE_GET_SUCCESS(0, "채팅 이전 메시지 목록 조회 성공"),
+
+    AUTH_TOKEN_REISSUE_SUCCESS(0, "토큰 재발급 성공");
 
     private final int code;
     private final String message;

--- a/src/main/java/plango/global/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/plango/global/config/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package plango.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import plango.global.common.response.CommonResponse;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        CommonResponse<Void> body = CommonResponse.fail(
+                HttpServletResponse.SC_UNAUTHORIZED,
+                "인증이 필요합니다."
+        );
+
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/src/main/java/plango/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/plango/global/config/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package plango.global.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import plango.auth.application.exception.AuthException;
+import plango.auth.domain.service.JwtTokenProvider;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null) {
+            try {
+                Long memberId = jwtTokenProvider.getMemberIdFromAccessToken(token);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                memberId,
+                                null,
+                                Collections.emptyList()
+                        );
+
+                authentication.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+
+                SecurityContextHolder.getContext()
+                        .setAuthentication(authentication);
+            } catch (AuthException exception) {
+                log.warn("JWT 인증 실패: {}", exception.getMessage());
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (!StringUtils.hasText(bearerToken)) {
+            return null;
+        }
+
+        if (!bearerToken.startsWith("Bearer ")) {
+            return null;
+        }
+
+        return bearerToken.substring(7);
+    }
+}

--- a/src/main/java/plango/global/config/SecurityConfig.java
+++ b/src/main/java/plango/global/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package plango.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import plango.auth.domain.service.JwtTokenProvider;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .httpBasic(Customizer.withDefaults())
+                .formLogin(form -> form.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/health-check",
+                                "/api/auth/**",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/ws/**"
+                        )
+                        .permitAll()
+                        .anyRequest()
+                        .authenticated()
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                );
+
+        http.addFilterBefore(
+                new JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter.class
+        );
+
+        return http.build();
+    }
+}

--- a/src/main/java/plango/global/config/SwaggerConfig.java
+++ b/src/main/java/plango/global/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package plango.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,11 +13,28 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI plangoOpenAPI() {
+        String securitySchemeName = "bearerAuth";
+
         return new OpenAPI()
-                .components(new Components())
-                .info(new Info()
-                        .title("PlanGo API")
-                        .description("PlanGo API 문서입니다.")
-                        .version("v1.0.0"));
+                .components(
+                        new Components()
+                                .addSecuritySchemes(
+                                        securitySchemeName,
+                                        new SecurityScheme()
+                                                .type(SecurityScheme.Type.HTTP)
+                                                .scheme("bearer")
+                                                .bearerFormat("JWT")
+                                )
+                )
+                .addSecurityItem(
+                        new SecurityRequirement()
+                                .addList(securitySchemeName)
+                )
+                .info(
+                        new Info()
+                                .title("PlanGo API")
+                                .description("PlanGo API 문서입니다.")
+                                .version("v1.0.0")
+                );
     }
 }

--- a/src/main/java/plango/notification/presentation/NotificationSettingController.java
+++ b/src/main/java/plango/notification/presentation/NotificationSettingController.java
@@ -2,10 +2,10 @@ package plango.notification.presentation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import plango.global.common.response.CommonResponse;
@@ -23,7 +23,7 @@ public class NotificationSettingController {
 
     @GetMapping
     public CommonResponse<NotificationSettingResponse> getMyNotificationSetting(
-            @RequestHeader("X-MEMBER-ID") Long memberId
+            @AuthenticationPrincipal Long memberId
     ) {
         NotificationSettingResponse response =
                 notificationSettingUseCase.getMyNotificationSetting(memberId);
@@ -36,7 +36,7 @@ public class NotificationSettingController {
 
     @PatchMapping
     public CommonResponse<NotificationSettingResponse> updateMyNotificationSetting(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @RequestBody @Valid NotificationSettingUpdateRequest request
     ) {
         NotificationSettingResponse response =

--- a/src/main/java/plango/room/presentation/RoomController.java
+++ b/src/main/java/plango/room/presentation/RoomController.java
@@ -4,18 +4,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
+import plango.room.application.dto.request.DelegateHostRequest;
 import plango.room.application.dto.request.RoomCreateRequest;
 import plango.room.application.dto.request.RoomUpdateRequest;
-import plango.room.application.dto.request.DelegateHostRequest;
 import plango.room.application.dto.response.RoomCreateResponse;
 import plango.room.application.dto.response.RoomUpdateResponse;
 import plango.room.application.usecase.CreateRoomUseCase;
@@ -33,7 +33,7 @@ public class RoomController {
     @PostMapping
     @Operation(summary = "여행방 생성", description = "로그인한 사용자를 방장으로 하여 여행방을 생성합니다.")
     public CommonResponse<RoomCreateResponse> createRoom(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody RoomCreateRequest request
     ) {
         RoomCreateResponse response = createRoomUseCase.execute(memberId, request);
@@ -41,10 +41,10 @@ public class RoomController {
     }
 
     @PatchMapping("/{roomId}")
-    @Operation(summary = "여행방 수정", description = "여행방 멤버, 방장, 방 정보를 수정합니다.")
+    @Operation(summary = "여행방 정보 수정", description = "여행방 제목, 설명, 일정 등을 수정합니다.")
     public CommonResponse<RoomUpdateResponse> updateRoom(
             @PathVariable Long roomId,
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody RoomUpdateRequest request
     ) {
         RoomUpdateResponse response = updateRoomUseCase.updateRoom(roomId, memberId, request);
@@ -55,7 +55,7 @@ public class RoomController {
     @Operation(summary = "여행방 방장 위임", description = "현재 방장이 다른 멤버에게 방장 권한을 위임합니다.")
     public CommonResponse<Void> delegateHost(
             @PathVariable Long roomId,
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody DelegateHostRequest request
     ) {
         updateRoomUseCase.delegateHost(roomId, memberId, request.newHostId());

--- a/src/main/java/plango/room/presentation/RoomGetController.java
+++ b/src/main/java/plango/room/presentation/RoomGetController.java
@@ -2,16 +2,21 @@ package plango.room.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 import plango.room.application.dto.response.RoomDetailResponse;
 import plango.room.application.dto.response.RoomListResponse;
-import plango.room.application.usecase.GetRoomListUseCase;
 import plango.room.application.usecase.GetRoomDetailUseCase;
-
-import java.util.List;
+import plango.room.application.usecase.GetRoomListUseCase;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +30,7 @@ public class RoomGetController {
     @GetMapping
     @Operation(summary = "여행방 목록 조회")
     public CommonResponse<List<RoomListResponse>> getRoomList(
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @RequestParam(value = "keyword", required = false) String keyword
     ) {
         List<RoomListResponse> result =
@@ -40,7 +45,7 @@ public class RoomGetController {
     @Operation(summary = "여행방 상세 조회")
     public CommonResponse<RoomDetailResponse> getRoomDetail(
             @PathVariable Long roomId,
-            @RequestHeader("X-MEMBER-ID") Long memberId
+            @AuthenticationPrincipal Long memberId
     ) {
         RoomDetailResponse response = getRoomDetailUseCase.execute(roomId, memberId);
         return CommonResponse.success(ResponseMessage.ROOM_DETAIL_GET_SUCCESS, response);

--- a/src/main/java/plango/room/presentation/RoomPlaceController.java
+++ b/src/main/java/plango/room/presentation/RoomPlaceController.java
@@ -3,16 +3,22 @@ package plango.room.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 import plango.room.application.dto.request.RoomPlaceCreateRequest;
 import plango.room.application.dto.response.RoomPlaceResponse;
 import plango.room.application.usecase.RoomPlaceCommandUseCase;
 import plango.room.application.usecase.RoomPlaceQueryUseCase;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,7 +42,7 @@ public class RoomPlaceController {
     @Operation(summary = "위시리스트 장소 생성", description = "여행방에 장소를 추가합니다.")
     public CommonResponse<RoomPlaceResponse> createPlace(
             @PathVariable Long roomId,
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody RoomPlaceCreateRequest request
     ) {
         RoomPlaceResponse response = roomPlaceCommandUseCase.createRoomPlace(

--- a/src/main/java/plango/room/presentation/RoomScheduleController.java
+++ b/src/main/java/plango/room/presentation/RoomScheduleController.java
@@ -3,16 +3,24 @@ package plango.room.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import plango.global.common.response.CommonResponse;
 import plango.global.common.response.ResponseMessage;
 import plango.room.application.dto.request.ScheduleCreateRequest;
 import plango.room.application.dto.response.ScheduleCreateResponse;
 import plango.room.application.usecase.RoomScheduleCommandUseCase;
 import plango.room.application.usecase.RoomScheduleQueryUseCase;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,10 +35,11 @@ public class RoomScheduleController {
     @Operation(summary = "일정 생성", description = "특정 날짜(dayIndex)에 일정을 생성합니다.")
     public CommonResponse<ScheduleCreateResponse> createSchedule(
             @PathVariable Long roomId,
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @Valid @RequestBody ScheduleCreateRequest request
     ) {
-        ScheduleCreateResponse response = roomScheduleCommandUseCase.createSchedule(memberId, roomId, request);
+        ScheduleCreateResponse response =
+                roomScheduleCommandUseCase.createSchedule(memberId, roomId, request);
         return CommonResponse.success(ResponseMessage.ROOM_SCHEDULE_CREATE_SUCCESS, response);
     }
 
@@ -40,15 +49,16 @@ public class RoomScheduleController {
             @PathVariable Long roomId,
             @RequestParam int dayIndex
     ) {
-        List<ScheduleCreateResponse> responses = roomScheduleQueryUseCase.getSchedules(roomId, dayIndex);
+        List<ScheduleCreateResponse> responses =
+                roomScheduleQueryUseCase.getSchedules(roomId, dayIndex);
         return CommonResponse.success(ResponseMessage.ROOM_SCHEDULE_GET_SUCCESS, responses);
     }
 
     @PatchMapping("/{scheduleId}")
-    @Operation(summary = "일정 수정", description = "시작/종료 시간 또는 메모를 수정합니다.")
+    @Operation(summary = "일정 수정", description = "일정의 시간 또는 메모를 수정합니다.")
     public CommonResponse<Void> updateSchedule(
             @PathVariable Long scheduleId,
-            @RequestHeader("X-MEMBER-ID") Long memberId,
+            @AuthenticationPrincipal Long memberId,
             @RequestParam(required = false) String startTime,
             @RequestParam(required = false) String endTime,
             @RequestParam(required = false) String memo
@@ -61,7 +71,7 @@ public class RoomScheduleController {
     @Operation(summary = "일정 삭제", description = "일정을 삭제합니다.")
     public CommonResponse<Void> deleteSchedule(
             @PathVariable Long scheduleId,
-            @RequestHeader("X-MEMBER-ID") Long memberId
+            @AuthenticationPrincipal Long memberId
     ) {
         roomScheduleCommandUseCase.deleteSchedule(memberId, scheduleId);
         return CommonResponse.success(ResponseMessage.ROOM_SCHEDULE_DELETE_SUCCESS);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,11 +55,15 @@ security:
   aes:
     key: ${AES_KEY:}
 
+  jwt:
+    secret-key: ${JWT_SECRET_KEY:plango-jwt-secret-key-change-me-please-very-long}
+    access-token-validity-in-seconds: ${JWT_ACCESS_TOKEN_VALIDITY:1800}
+    refresh-token-validity-in-seconds: ${JWT_REFRESH_TOKEN_VALIDITY:1209600}
+
   preview:
     api:
       url: ${PREVIEW_API_URL:http://localhost:3000}
   oauth2:
     kakao:
       client-id: ${KAKAO_CLIENT_ID}
-
       redirect-uri: ${KAKAO_REDIRECT_URI}


### PR DESCRIPTION
## ✨ 관련 이슈

- Resolved: #91 

🔎 작업 내용

- JWT 기반 인증/인가 구조를 전체적으로 리팩토링하여 일관된 보안 흐름을 적용했습니다.
- JwtAuthenticationFilter에서 AccessToken을 검증하고, 인증된 사용자의 memberId를 Spring Security Authentication 객체로 주입하도록 변경했습니다.
- 기존의 X-MEMBER-ID 헤더 기반 방식은 제거하고, 모든 인증이 필요한 API는 @AuthenticationPrincipal Long memberId 로 로그인 사용자를 식별하도록 전면 개편했습니다.
- AccessToken + RefreshToken 이중 구조를 적용하고, /api/auth/reissue 를 통해 만료된 AccessToken 재발급 흐름을 안정적으로 관리할 수 있도록 구현했습니다.
- Swagger 문서에 bearerAuth SecurityScheme을 추가하여, Swagger UI 상에서도 JWT 기반 인증이 정상적으로 동작하도록 개선했습니다.
- 전체 컨트롤러의 인증 방식이 JWT 기반으로 통일되어, 보안성과 유지보수성이 크게 향상되었습니다.

<br>

📌 참고 사항

- 🔐 Authorize 버튼에는 하나의 사용자 JWT만 등록할 수 있습니다.
- 여러 사용자 시나리오 테스트 시에는 토큰을 교체하거나, 브라우저 창을 분리하여 테스트해야 합니다.
- ⚠️ 모든 조회 API는 “현재 토큰을 소유한 사용자 기준”으로 동작합니다.
- 예: 친구 목록 조회, 여행방 목록 조회 등은 항상 로그인된 사용자의 정보를 기준으로 조회됩니다.
- 🔄 AccessToken이 만료되면 RefreshToken을 사용하여 /api/auth/reissue 로 재발급이 가능합니다.
- 🧪 리팩토링 이후 전체 Swagger 테스트(프로필 조회/친구 기능/여행방/일정/채팅 등) 전부 정상 동작 확인했습니다.

<br>

📌 주의해야 할 점
- Authorization 헤더는 반드시 아래 형식을 따라야 합니다.
Authorization: Bearer {accessToken}
- RefreshToken은 재발급 시에만 사용되며, 일반 API 호출에서는 사용되지 않습니다.
- 회원탈퇴/카카오 로그인/친구 기능 등 기존 기능과의 충돌 없이 동작하도록 전체 코드에 반영 완료했습니다.

<br>

## 📷 이미지 첨부
- 사진에 대한 설명
  <br>
  <img src="파일주소" width="50%" height="50%"/>

<br/>

---

## ✅ Check List
- [ ] 라벨 지정
- [ ] 리뷰어 지정
- [ ] 담당자 지정
- [ ] 테스트 완료
- [ ] 이슈 제목 컨벤션 준수
- [ ] PR 제목 및 설명 작성
- [ ] 커밋 메시지 컨벤션 준수